### PR TITLE
Make credentials optional in maskCredentials tool

### DIFF
--- a/packages/core/graphql/resolvers/call.ts
+++ b/packages/core/graphql/resolvers/call.ts
@@ -11,7 +11,7 @@ export const callResolver = async (
   { input, payload, credentials, options }: { 
     input: ApiInputRequest; 
     payload: any; 
-    credentials: Record<string, string>;
+    credentials?: Record<string, string>;
     options: RequestOptions; 
   },
   context: Context,

--- a/packages/core/utils/tools.test.ts
+++ b/packages/core/utils/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { composeUrl, replaceVariables, applyJsonata, applyJsonataWithValidation, getAllKeys, applyAuthFormat, sample } from './tools.js'
+import { composeUrl, replaceVariables, applyJsonata, applyJsonataWithValidation, getAllKeys, applyAuthFormat, sample, maskCredentials } from './tools.js'
 
 describe('tools utility functions', () => {
   describe('composeUrl', () => {
@@ -167,6 +167,21 @@ describe('tools utility functions', () => {
       const arr = Array.from({ length: 100 }, (_, i) => i);
       const result = sample(arr, 5);
       expect(result).toHaveLength(5);
+    });
+  });
+
+  describe('maskCredentials', () => {
+    it('should mask credentials in message globally', () => {
+      const message = 'My password is 123456. Remember it is 123456! My username is admin.';
+      const credentials = { password: '123456', username: 'admin' };
+      const result = maskCredentials(message, credentials);
+      expect(result).toBe('My password is {masked_password}. Remember it is {masked_password}! My username is {masked_username}.');
+    });
+
+    it('should return message if no credentials are provided', () => {
+      const message = 'My password is 123456';
+      const result = maskCredentials(message);
+      expect(result).toBe(message);
     });
   });
 }) 

--- a/packages/core/utils/tools.ts
+++ b/packages/core/utils/tools.ts
@@ -164,7 +164,11 @@ export function sample<T>(arr: any, sampleSize = 10): T[] {
   return result;
 }
 
-export function maskCredentials(message: string, credentials: Record<string, string>): string {
+export function maskCredentials(message: string, credentials?: Record<string, string>): string {
+  if (!credentials) {
+    return message;
+  }
+
   let maskedMessage = message;
   Object.entries(credentials).forEach(([key, value]) => {
     if (value && value.length > 0) {


### PR DESCRIPTION
## Bug: TypeError when optional credentials are not provided

### Description
Following the README examples with optional credentials results in a TypeError in `maskCredentials` function, despite credentials being correctly marked as optional in GraphQL schema.
<img width="941" alt="Screenshot 2025-02-06 at 17 48 52" src="https://github.com/user-attachments/assets/a512a617-7de0-4a7c-8538-866b69bc2dc3" />
<img width="913" alt="Screenshot 2025-02-06 at 17 49 36" src="https://github.com/user-attachments/assets/7ce39b22-09f2-43dc-8b9a-47fd8f1a6651" />


### Changes
- Added proper type handling in `maskCredentials` function
- Added test cases to verify behavior with undefined credentials
- Ensures type safety while maintaining existing functionality

### Test Cases Added
- Test case verifying message is returned unchanged when no credentials are provided
- Test case verifying proper masking when credentials are provided
- Test case verifying global replacement of credential values

### Impact
Aligns implementation with documentation, allowing developers to safely follow README examples without encountering runtime errors when credentials are omitted.