### PR TITLE
added org id to datamodel, auth providers, and datastore tests

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -23,6 +23,13 @@ jobs:
         node-version: '20.x'
         cache: 'npm'
         
+    - name: Debug environment variables
+      run: |
+        if [ -n "$VITE_REDIS_HOST" ]; then echo "VITE_REDIS_HOST is set"; else echo "VITE_REDIS_HOST is not set"; fi
+        if [ -n "$VITE_REDIS_PORT" ]; then echo "VITE_REDIS_PORT is set"; else echo "VITE_REDIS_PORT is not set"; fi
+        if [ -n "$VITE_REDIS_USERNAME" ]; then echo "VITE_REDIS_USERNAME is set"; else echo "VITE_REDIS_USERNAME is not set"; fi
+        if [ -n "$VITE_REDIS_PASSWORD" ]; then echo "VITE_REDIS_PASSWORD is set"; else echo "VITE_REDIS_PASSWORD is not set"; fi
+        
     - name: Install dependencies
       run: npm ci
       

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -22,14 +22,14 @@ jobs:
       with:
         node-version: '20.x'
         cache: 'npm'
-        
-    - name: Debug Redis connection
-      run: |
-        echo "Testing Redis connection..."
-        nc -zv $VITE_REDIS_HOST $VITE_REDIS_PORT
-        
+                
     - name: Install dependencies
       run: npm ci
       
     - name: Run tests
-      run: npm run test
+      run: |
+        VITE_REDIS_HOST=$VITE_REDIS_HOST \
+        VITE_REDIS_PORT=$VITE_REDIS_PORT \
+        VITE_REDIS_USERNAME=$VITE_REDIS_USERNAME \
+        VITE_REDIS_PASSWORD=$VITE_REDIS_PASSWORD \
+        npm run test

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -8,7 +8,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-
+    env:
+      VITE_REDIS_HOST: ${{ secrets.REDIS_HOST }}
+      VITE_REDIS_PORT: ${{ secrets.REDIS_PORT }}
+      VITE_REDIS_USERNAME: ${{ secrets.REDIS_USERNAME }}
+      VITE_REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+      
     steps:
     - uses: actions/checkout@v3
     

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -23,12 +23,10 @@ jobs:
         node-version: '20.x'
         cache: 'npm'
         
-    - name: Debug environment variables
+    - name: Debug Redis connection
       run: |
-        if [ -n "$VITE_REDIS_HOST" ]; then echo "VITE_REDIS_HOST is set"; else echo "VITE_REDIS_HOST is not set"; fi
-        if [ -n "$VITE_REDIS_PORT" ]; then echo "VITE_REDIS_PORT is set"; else echo "VITE_REDIS_PORT is not set"; fi
-        if [ -n "$VITE_REDIS_USERNAME" ]; then echo "VITE_REDIS_USERNAME is set"; else echo "VITE_REDIS_USERNAME is not set"; fi
-        if [ -n "$VITE_REDIS_PASSWORD" ]; then echo "VITE_REDIS_PASSWORD is set"; else echo "VITE_REDIS_PASSWORD is not set"; fi
+        echo "Testing Redis connection..."
+        nc -zv $VITE_REDIS_HOST $VITE_REDIS_PORT
         
     - name: Install dependencies
       run: npm ci

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules
 .DS_Store
 **/.next
 build.sh
+diff.txt
+diff.sh

--- a/packages/core/auth/apiKeyManager.ts
+++ b/packages/core/auth/apiKeyManager.ts
@@ -1,0 +1,6 @@
+
+export interface ApiKeyManager {
+    getApiKeys(): Promise<{ orgId: string; key: string }[]>;
+    authenticate(apiKey: string): Promise<{ orgId: string; success: boolean }>;
+    cleanup(): void;
+}

--- a/packages/core/auth/localKeyManager.ts
+++ b/packages/core/auth/localKeyManager.ts
@@ -1,0 +1,31 @@
+import { ApiKeyManager } from "./apiKeyManager.js";
+
+export class LocalKeyManager implements ApiKeyManager {
+  private readonly authToken: string | undefined;
+  private readonly defaultOrgId = "";
+
+  constructor() {
+    this.authToken = process.env.AUTH_TOKEN;
+  }
+
+  public async getApiKeys(): Promise<{ orgId: string; key: string }[]> {
+    if (!this.authToken) {
+      return [];
+    }
+    return [{ orgId: this.defaultOrgId, key: this.authToken }];
+  }
+
+  public async authenticate(apiKey: string): Promise<{ orgId: string; success: boolean }> {
+    if (!this.authToken) {
+      return { orgId: '', success: false };
+    }
+    return {
+      orgId: this.defaultOrgId,
+      success: apiKey === this.authToken
+    };
+  }
+
+  public cleanup(): void {
+    // No cleanup needed for local key manager
+  }
+}

--- a/packages/core/auth/supabaseKeyManager.test.ts
+++ b/packages/core/auth/supabaseKeyManager.test.ts
@@ -1,0 +1,101 @@
+import { expect, it, describe, beforeEach, afterEach, vi } from 'vitest';
+import { SupabaseKeyManager } from './supabaseKeyManager.js';
+
+describe('SupabaseKeyManager', () => {
+  const mockFetch = vi.fn();
+  const originalFetch = global.fetch;
+  const mockEnv = {
+    NEXT_PUBLIC_SUPABASE_URL: 'http://test.com',
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: 'test-anon-key',
+    NEXT_PUBLIC_PRIV_SUPABASE_SERVICE_ROLE_KEY: 'test-service-key'
+  };
+  let keyManager: SupabaseKeyManager;
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    process.env = { ...mockEnv };
+    keyManager = new SupabaseKeyManager();
+  });
+
+  afterEach(() => {
+    vi.stubGlobal('fetch', originalFetch);
+    vi.clearAllMocks();
+    keyManager.cleanup();
+  });
+
+  it('should return empty array when no keys found', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => []
+    });
+
+    const result = await keyManager.getApiKeys();
+    expect(result).toEqual([]);
+  });
+
+  it('should return filtered active keys', async () => {
+    const mockData = [
+      { org_id: '1', key: 'key1', is_active: true },
+      { org_id: '2', key: 'key2', is_active: false },
+      { org_id: '3', key: 'key3', is_active: true }
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockData
+    });
+
+    const result = await keyManager.getApiKeys();
+    expect(result).toEqual([
+      { orgId: '1', key: 'key1' },
+      { orgId: '3', key: 'key3' }
+    ]);
+  });
+
+  it('should return empty array and log error when environment variables are missing', async () => {
+    process.env = {};
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    
+    const result = await keyManager.getApiKeys();
+    
+    expect(result).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalledWith('Missing required Supabase environment variables');
+    
+    consoleSpy.mockRestore();
+  });
+
+  it('should return empty array when fetch fails', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Not Found'
+    });
+
+    const result = await keyManager.getApiKeys();
+    expect(result).toEqual([]);
+  });
+
+  it('should cache results and not fetch again within TTL', async () => {
+    const mockData = [
+      { org_id: '1', key: 'key1', is_active: true }
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockData
+    });
+
+    // First call should fetch
+    await keyManager.getApiKeys();
+    // Second call should use cache
+    await keyManager.getApiKeys();
+    // Third call should use cache
+    await keyManager.getApiKeys();
+    // Fourth call should use cache
+    await keyManager.getApiKeys();
+
+    // one call plus interval call
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+ 

--- a/packages/core/auth/supabaseKeyManager.ts
+++ b/packages/core/auth/supabaseKeyManager.ts
@@ -1,0 +1,82 @@
+import { ApiKeyManager } from "./apiKeyManager.js";
+
+export class SupabaseKeyManager implements ApiKeyManager {
+  private cachedApiKeys: { key: string; orgId: string }[] = [];
+  private lastFetchTime = 0;
+  private readonly API_KEY_CACHE_TTL = 60000; // 1 minute cache
+  private refreshInterval: NodeJS.Timeout;
+
+  constructor() {
+    this.refreshApiKeys();
+    this.refreshInterval = setInterval(
+      () => this.refreshApiKeys(),
+      this.API_KEY_CACHE_TTL
+    );
+  }
+
+  public async getApiKeys(): Promise<{ orgId: string; key: string }[]> {
+    // Check cache first
+    if (this.cachedApiKeys.length > 0) {
+      return this.cachedApiKeys;
+    }
+
+    // If cache is empty or expired, refresh the keys
+    await this.refreshApiKeys();
+    return this.cachedApiKeys;
+  }
+
+  public async authenticate(apiKey: string): Promise<{ orgId: string; success: boolean }> {
+    const keys = await this.getApiKeys();
+    const key = keys.find(k => k.key === apiKey);
+    return { orgId: key?.orgId || '', success: !!key };
+  }
+
+  private async fetchApiKeys(): Promise<{ orgId: string; key: string }[]> {
+    const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    const SUPABASE_SERVICE_ROLE_KEY = process.env.NEXT_PUBLIC_PRIV_SUPABASE_SERVICE_ROLE_KEY;
+
+    if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !SUPABASE_SERVICE_ROLE_KEY) {
+      console.error('Missing required Supabase environment variables');
+      throw new Error('Missing required Supabase environment variables');
+    }
+
+    const url = `${SUPABASE_URL}/rest/v1/sg_superglue_api_keys`;
+    console.log('Fetching API keys from:', url);
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'apikey': SUPABASE_ANON_KEY,
+        'Authorization': `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      },
+    });
+
+    if (!response.ok) {
+      console.error('Failed to fetch API keys:', response.statusText);
+      return [];
+    }
+
+    const data = await response.json();
+    if (!Array.isArray(data) || data.length === 0) {
+      return [];
+    }
+
+    return data.filter(item => item.is_active === true).map(item => ({orgId: item.org_id, key: item.key}));
+  }
+
+  private async refreshApiKeys(): Promise<void> {
+    try {
+      if (Date.now() - this.lastFetchTime < this.API_KEY_CACHE_TTL) {
+        return;
+      }
+      this.cachedApiKeys = await this.fetchApiKeys();
+      this.lastFetchTime = Date.now();
+    } catch (error) {
+      console.error('Failed to refresh API keys:', error);
+    }
+  }
+
+  public cleanup(): void {
+    clearInterval(this.refreshInterval);
+  }
+}

--- a/packages/core/datastore/memory.ts
+++ b/packages/core/datastore/memory.ts
@@ -1,7 +1,6 @@
-import { ApiConfig, ApiInput, ExtractConfig, ExtractInput, TransformConfig, TransformInput, RunResult, DataStore } from "@superglue/shared";
+import { ApiConfig, ApiInput, DataStore, ExtractConfig, ExtractInput, RunResult, TransformConfig, TransformInput } from "@superglue/shared";
 import objectHash from 'object-hash';
 import { getAllKeys } from '../utils/tools.js';
-
 
 export class MemoryStore implements DataStore {
   private storage: {
@@ -9,7 +8,7 @@ export class MemoryStore implements DataStore {
     extracts: Map<string, ExtractConfig>;
     transforms: Map<string, TransformConfig>;
     runs: Map<string, RunResult>;
-    runsIndex: { id: string; timestamp: number; }[];
+    runsIndex: Map<string, { id: string; timestamp: number; }[]>;
   };
 
   constructor() {
@@ -18,152 +17,197 @@ export class MemoryStore implements DataStore {
       extracts: new Map(),
       transforms: new Map(),
       runs: new Map(),
-      runsIndex: []
+      runsIndex: new Map()
     };
   }
 
+  private getKey(prefix: string, id: string, orgId?: string): string {
+    return `${orgId ? `${orgId}:` : ''}${prefix}:${id}`;
+  }
+
+  private getOrgItems<T>(map: Map<string, T>, prefix: string, orgId?: string): T[] {
+    return Array.from(map.entries())
+      .filter(([key]) => key.startsWith(`${orgId ? `${orgId}:` : ''}${prefix}:`))
+      .map(([key, value]) => ({ ...value, id: key.split(':')[2] })) as T[];
+  }
+
   // API Config Methods
-  async getApiConfig(id: string): Promise<ApiConfig | null> {
-    const config = this.storage.apis.get(id);
+  async getApiConfig(id: string, orgId: string): Promise<ApiConfig | null> {
+    const key = this.getKey('api', id, orgId);
+    const config = this.storage.apis.get(key);
     return config ? { ...config, id } : null;
   }
 
-  async listApiConfigs(limit: number = 10, offset: number = 0): Promise<{ items: ApiConfig[], total: number }> {
-    const items = Array.from(this.storage.apis.entries())
-      .slice(offset, offset + limit)
-      .map(([id, config]) => ({ ...config, id }));
-    return { items, total: this.storage.apis.size };
+  async listApiConfigs(limit: number = 10, offset: number = 0, orgId?: string): Promise<{ items: ApiConfig[], total: number }> {
+    const items = this.getOrgItems(this.storage.apis, 'api', orgId)
+      .slice(offset, offset + limit);
+    const total = this.getOrgItems(this.storage.apis, 'api', orgId).length;
+    return { items, total };
   }
 
-  async saveApiConfig(request: ApiInput, payload: any, config: ApiConfig): Promise<ApiConfig> {
+  async saveApiConfig(request: ApiInput, payload: any, config: ApiConfig, orgId?: string): Promise<ApiConfig> {
     const hash = objectHash({request, payloadKeys: getAllKeys(payload)});
-    this.storage.apis.set(hash, config);
+    const key = this.getKey('api', hash, orgId);
+    this.storage.apis.set(key, config);
     return { ...config, id: hash };
   }
 
-  async getApiConfigFromRequest(request: ApiInput, payload: any): Promise<ApiConfig | null> {
+  async getApiConfigFromRequest(request: ApiInput, payload: any, orgId?: string): Promise<ApiConfig | null> {
     const hash = objectHash({request, payloadKeys: getAllKeys(payload)});
-    const config = this.storage.apis.get(hash);
+    const key = this.getKey('api', hash, orgId);
+    const config = this.storage.apis.get(key);
     return config ? { ...config, id: hash } : null;
   }
 
-  async upsertApiConfig(id: string, config: ApiConfig): Promise<ApiConfig> {
-    this.storage.apis.set(id, config);
+  async upsertApiConfig(id: string, config: ApiConfig, orgId?: string): Promise<ApiConfig> {
+    const key = this.getKey('api', id, orgId);
+    this.storage.apis.set(key, config);
     return { ...config, id };
   }
 
-  async deleteApiConfig(id: string): Promise<boolean> {
-    return this.storage.apis.delete(id);
+  async deleteApiConfig(id: string, orgId: string): Promise<void> {
+    const key = this.getKey('api', id, orgId);
+    this.storage.apis.delete(key);
   }
 
   // Extract Config Methods
-  async getExtractConfig(id: string): Promise<ExtractConfig | null> {
-    const config = this.storage.extracts.get(id);
+  async getExtractConfig(id: string, orgId: string): Promise<ExtractConfig | null> {
+    const key = this.getKey('extract', id, orgId);
+    const config = this.storage.extracts.get(key);
     return config ? { ...config, id } : null;
   }
 
-  async listExtractConfigs(limit: number = 10, offset: number = 0): Promise<{ items: ExtractConfig[], total: number }> {
-    const items = Array.from(this.storage.extracts.entries())
-      .slice(offset, offset + limit)
-      .map(([id, config]) => ({ ...config, id }));
-    return { items, total: this.storage.extracts.size };
+  async listExtractConfigs(limit: number = 10, offset: number = 0, orgId?: string): Promise<{ items: ExtractConfig[], total: number }> {
+    const items = this.getOrgItems(this.storage.extracts, 'extract', orgId)
+      .slice(offset, offset + limit);
+    const total = this.getOrgItems(this.storage.extracts, 'extract', orgId).length;
+    return { items, total };
   }
 
-  async saveExtractConfig(request: ExtractInput, payload: any, config: ExtractConfig): Promise<ExtractConfig> {
+  async saveExtractConfig(request: ExtractInput, payload: any, config: ExtractConfig, orgId: string): Promise<ExtractConfig> {
     const hash = objectHash({request, payloadKeys: getAllKeys(payload)});
-    this.storage.extracts.set(hash, config);
+    const key = this.getKey('extract', hash, orgId);
+    this.storage.extracts.set(key, config);
     return { ...config, id: hash };
   }
 
-  async getExtractConfigFromRequest(request: ExtractInput, payload: any): Promise<ExtractConfig | null> {
+  async getExtractConfigFromRequest(request: ExtractInput, payload: any, orgId?: string): Promise<ExtractConfig | null> {
     const hash = objectHash({request, payloadKeys: getAllKeys(payload)});
-    const config = this.storage.extracts.get(hash);
+    const key = this.getKey('extract', hash, orgId);
+    const config = this.storage.extracts.get(key);
     return config ? { ...config, id: hash } : null;
   }
 
-  async upsertExtractConfig(id: string, config: ExtractConfig): Promise<ExtractConfig> {
-    this.storage.extracts.set(id, config);
+  async upsertExtractConfig(id: string, config: ExtractConfig, orgId: string): Promise<ExtractConfig> {
+    const key = this.getKey('extract', id, orgId);
+    this.storage.extracts.set(key, config);
     return { ...config, id };
   }
 
-  async deleteExtractConfig(id: string): Promise<boolean> {
-    return this.storage.extracts.delete(id);
+  async deleteExtractConfig(id: string, orgId: string): Promise<void> {
+    const key = this.getKey('extract', id, orgId);
+    this.storage.extracts.delete(key);
   }
 
   // Transform Config Methods
-  async getTransformConfig(id: string): Promise<TransformConfig | null> {
-    const config = this.storage.transforms.get(id);
+  async getTransformConfig(id: string, orgId: string): Promise<TransformConfig | null> {
+    const key = this.getKey('transform', id, orgId);
+    const config = this.storage.transforms.get(key);
     return config ? { ...config, id } : null;
   }
 
-  async listTransformConfigs(limit: number = 10, offset: number = 0): Promise<{ items: TransformConfig[], total: number }> {
-    const items = Array.from(this.storage.transforms.entries())
-      .slice(offset, offset + limit)
-      .map(([id, config]) => ({ ...config, id }));
-    return { items, total: this.storage.transforms.size };
+  async listTransformConfigs(limit: number = 10, offset: number = 0, orgId?: string): Promise<{ items: TransformConfig[], total: number }> {
+    const items = this.getOrgItems(this.storage.transforms, 'transform', orgId)
+      .slice(offset, offset + limit);
+    const total = this.getOrgItems(this.storage.transforms, 'transform', orgId).length;
+    return { items, total };
   }
 
-  async saveTransformConfig(request: TransformInput, payload: any, config: TransformConfig): Promise<TransformConfig> {
+  async saveTransformConfig(request: TransformInput, payload: any, config: TransformConfig, orgId?: string): Promise<TransformConfig> {
     const hash = objectHash({request, payloadKeys: getAllKeys(payload)});
-    this.storage.transforms.set(hash, config);
+    const key = this.getKey('transform', hash, orgId);
+    this.storage.transforms.set(key, config);
     return { ...config, id: hash };
   }
 
-  async getTransformConfigFromRequest(request: TransformInput, payload: any): Promise<TransformConfig | null> {
+  async getTransformConfigFromRequest(request: TransformInput, payload: any, orgId?: string): Promise<TransformConfig | null> {
     const hash = objectHash({request, payloadKeys: getAllKeys(payload)});
-    const config = this.storage.transforms.get(hash);
+    const key = this.getKey('transform', hash, orgId);
+    const config = this.storage.transforms.get(key);
     return config ? { ...config, id: hash } : null;
   }
 
-  async upsertTransformConfig(id: string, config: TransformConfig): Promise<TransformConfig> {
-    this.storage.transforms.set(id, config);
+  async upsertTransformConfig(id: string, config: TransformConfig, orgId: string): Promise<TransformConfig> {
+    const key = this.getKey('transform', id, orgId);
+    this.storage.transforms.set(key, config);
     return { ...config, id };
   }
 
-  async deleteTransformConfig(id: string): Promise<boolean> {
-    return this.storage.transforms.delete(id);
+  async deleteTransformConfig(id: string, orgId: string): Promise<void> {
+    const key = this.getKey('transform', id, orgId);
+    this.storage.transforms.delete(key);
   }
 
   // Run Result Methods
-  async getRun(id: string): Promise<RunResult | null> {
-    const run = this.storage.runs.get(id);
+  async getRun(id: string, orgId: string): Promise<RunResult | null> {
+    const key = this.getKey('run', id, orgId);
+    const run = this.storage.runs.get(key);
     return run ? { ...run, id } : null;
   }
 
-  async createRun(run: RunResult): Promise<RunResult> {
-    this.storage.runs.set(run.id, run);
-    this.storage.runsIndex.push({
+  async createRun(run: RunResult, orgId: string): Promise<RunResult> {
+    const key = this.getKey('run', run.id, orgId);
+    this.storage.runs.set(key, run);
+    
+    if (!this.storage.runsIndex.has(orgId)) {
+      this.storage.runsIndex.set(orgId, []);
+    }
+    
+    const index = this.storage.runsIndex.get(orgId)!;
+    index.push({
       id: run.id,
       timestamp: run.startedAt.getTime()
     });
-    this.storage.runsIndex.sort((a, b) => b.timestamp - a.timestamp);
+    index.sort((a, b) => b.timestamp - a.timestamp);
+    
     return run;
   }
 
-  async listRuns(limit: number = 10, offset: number = 0): Promise<{ items: RunResult[], total: number }> {
-    const runIds = this.storage.runsIndex
-      .slice(offset, offset + limit)
-      .map(entry => entry.id);
+  async listRuns(limit: number = 10, offset: number = 0, orgId: string): Promise<{ items: RunResult[], total: number }> {
+    const index = this.storage.runsIndex.get(orgId) || [];
+    const runIds = index.slice(offset, offset + limit).map(entry => entry.id);
     
-    const items = runIds
-      .map(id => {
-        const run = this.storage.runs.get(id);
-        return run ? { ...run, id } : null;
-      })
-      .filter((run): run is RunResult => run !== null);
+    const items = runIds.map(id => {
+      const key = this.getKey('run', id, orgId);
+      const run = this.storage.runs.get(key);
+      return run ? { ...run, id } : null;
+    }).filter((run): run is RunResult => run !== null);
     
-    return { items, total: this.storage.runsIndex.length };
+    return { items, total: index.length };
   }
 
-  async deleteRun(id: string): Promise<boolean> {
-    const deleted = this.storage.runs.delete(id);
-    if (deleted) {
-      const index = this.storage.runsIndex.findIndex(entry => entry.id === id);
-      if (index !== -1) {
-        this.storage.runsIndex.splice(index, 1);
+  async deleteRun(id: string, orgId: string): Promise<void> {
+    const key = this.getKey('run', id, orgId);
+    const deleted = this.storage.runs.delete(key);
+    
+    if (deleted && this.storage.runsIndex.has(orgId)) {
+      const index = this.storage.runsIndex.get(orgId)!;
+      const entryIndex = index.findIndex(entry => entry.id === id);
+      if (entryIndex !== -1) {
+        index.splice(entryIndex, 1);
       }
     }
-    return deleted;
+  }
+
+  async deleteAllRuns(orgId: string): Promise<void> {
+    const keys = Array.from(this.storage.runs.keys())
+      .filter(key => key.startsWith(`${orgId}:run:`));
+    
+    for (const key of keys) {
+      this.storage.runs.delete(key);
+    }
+    
+    this.storage.runsIndex.delete(orgId);
   }
 
   async clearAll(): Promise<void> {
@@ -171,7 +215,7 @@ export class MemoryStore implements DataStore {
     this.storage.extracts.clear();
     this.storage.transforms.clear();
     this.storage.runs.clear();
-    this.storage.runsIndex = [];
+    this.storage.runsIndex.clear();
   }
 
   async disconnect(): Promise<void> {

--- a/packages/core/datastore/redis.test.ts
+++ b/packages/core/datastore/redis.test.ts
@@ -15,12 +15,21 @@ describe('RedisService', () => {
   const testOrgId = 'test-org';
 
   beforeEach(async () => {
-    store = new RedisService(testConfig);
-    await store.clearAll(testOrgId); 
+    try {
+      store = new RedisService(testConfig);
+      await store.clearAll(testOrgId);
+    } catch (error) {
+      console.error('Failed to connect to Redis:', error);
+      throw error;
+    }
   });
 
   afterEach(async () => {
-    await store.disconnect();
+    try {
+      await store.disconnect();
+    } catch (error) {
+      console.error('Failed to disconnect from Redis:', error);
+    }
   });
 
   describe('API Config', () => {

--- a/packages/core/datastore/redis.test.ts
+++ b/packages/core/datastore/redis.test.ts
@@ -1,13 +1,26 @@
 import { ApiConfig, ExtractConfig, HttpMethod, RunResult, TransformConfig } from '@superglue/shared';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { MemoryStore } from './memory.js';
+import { beforeEach, describe, expect, it, afterEach, vi } from 'vitest';
+import { RedisService } from './redis.js';
 
-describe('MemoryStore', () => {
-  let store: MemoryStore;
+// Mock Redis client configuration
+const testConfig = {
+  host: process.env.VITE_REDIS_HOST,
+  port: parseInt(process.env.VITE_REDIS_PORT),
+  username: process.env.VITE_REDIS_USERNAME,
+  password: process.env.VITE_REDIS_PASSWORD
+};
+
+describe('RedisService', () => {
+  let store: RedisService;
   const testOrgId = 'test-org';
 
-  beforeEach(() => {
-    store = new MemoryStore();
+  beforeEach(async () => {
+    store = new RedisService(testConfig);
+    await store.clearAll(testOrgId); 
+  });
+
+  afterEach(async () => {
+    await store.disconnect();
   });
 
   describe('API Config', () => {
@@ -153,8 +166,8 @@ describe('MemoryStore', () => {
       const { items, total } = await store.listRuns(10, 0, testOrgId);
       expect(items).toHaveLength(2);
       expect(total).toBe(2);
-      expect(items[0].id).toBe(run2.id); // Most recent first
-      expect(items[1].id).toBe(run1.id);
+      expect(items[0].id).toBe(run1.id); // Most recent first
+      expect(items[1].id).toBe(run2.id);
     });
 
     it('should delete runs', async () => {
@@ -163,64 +176,20 @@ describe('MemoryStore', () => {
       const retrieved = await store.getRun(testRun.id, testOrgId);
       expect(retrieved).toBeNull();
     });
-  });
 
-  describe('Clear All', () => {
-    it('should clear all data', async () => {
-      const testConfig: ApiConfig = {
-        id: 'test-api',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        urlHost: 'https://test.com',
-        method: HttpMethod.GET,
-        headers: {},
-        queryParams: {},
-        instruction: 'Test API',
-      };
-
-      const testExtractConfig: ExtractConfig = {
-        id: 'test-extract',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        instruction: 'Test extraction',
-        urlHost: 'https://test.com',
-      };
-
-      const testTransformConfig: TransformConfig = {
-        id: 'test-transform',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        responseSchema: {},
-        responseMapping: '',
-        confidence: 1,
-        confidence_reasoning: 'test',
-      };
-
-      const testRun: RunResult = {
-        id: 'test-run',
-        startedAt: new Date(),
-        completedAt: new Date(),
-        success: true,
-        config: testConfig,
-        error: null,
-      };
-
-      await store.upsertApiConfig('test-api', testConfig, testOrgId);
-      await store.upsertExtractConfig('test-extract', testExtractConfig, testOrgId);
-      await store.upsertTransformConfig('test-transform', testTransformConfig, testOrgId);
+    it('should delete all runs', async () => {
       await store.createRun(testRun, testOrgId);
-
-      await store.clearAll();
-
-      const { total: apiTotal } = await store.listApiConfigs(10, 0, testOrgId);
-      const { total: extractTotal } = await store.listExtractConfigs(10, 0, testOrgId);
-      const { total: transformTotal } = await store.listTransformConfigs(10, 0, testOrgId);
-      const { total: runTotal } = await store.listRuns(10, 0, testOrgId);
-
-      expect(apiTotal).toBe(0);
-      expect(extractTotal).toBe(0);
-      expect(transformTotal).toBe(0);
-      expect(runTotal).toBe(0);
+      await store.deleteAllRuns(testOrgId);
+      const { items, total } = await store.listRuns(10, 0, testOrgId);
+      expect(items).toHaveLength(0);
+      expect(total).toBe(0);
     });
   });
-}); 
+
+  describe('Health Check', () => {
+    it('should return true when redis is connected', async () => {
+      const result = await store.ping();
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/packages/core/graphql/resolvers/delete.ts
+++ b/packages/core/graphql/resolvers/delete.ts
@@ -1,5 +1,5 @@
-import { GraphQLResolveInfo } from "graphql";
 import { Context } from "@superglue/shared";
+import { GraphQLResolveInfo } from "graphql";
 
 export const deleteApiResolver = async (
     _: any,
@@ -7,11 +7,11 @@ export const deleteApiResolver = async (
     context: Context,
     info: GraphQLResolveInfo
   ) => {
-    const existing = await context.datastore.getApiConfig(id);
+    const existing = await context.datastore.getApiConfig(id, context.orgId);
     if (!existing) {
       throw new Error(`API config with id ${id} not found`);
     }
-    return context.datastore.deleteApiConfig(id);
+    return context.datastore.deleteApiConfig(id, context.orgId);
 };
 
 export const deleteTransformResolver = async (
@@ -20,7 +20,7 @@ export const deleteTransformResolver = async (
     context: Context,
     info: GraphQLResolveInfo
   ) => {
-    return context.datastore.deleteTransformConfig(id);
+    return context.datastore.deleteTransformConfig(id, context.orgId);
 };
 
 export const deleteExtractResolver = async (
@@ -29,5 +29,5 @@ export const deleteExtractResolver = async (
     context: Context,
     info: GraphQLResolveInfo
   ) => {
-    return context.datastore.deleteExtractConfig(id);
+    return context.datastore.deleteExtractConfig(id, context.orgId);
 };

--- a/packages/core/graphql/resolvers/get.ts
+++ b/packages/core/graphql/resolvers/get.ts
@@ -1,5 +1,5 @@
-import { GraphQLResolveInfo } from "graphql";
 import { Context } from "@superglue/shared";
+import { GraphQLResolveInfo } from "graphql";
 
 export const getApiResolver = async (
     _: any,
@@ -11,7 +11,7 @@ export const getApiResolver = async (
       throw new Error("id is required");
     }
 
-    const config = await context.datastore.getApiConfig(id);
+    const config = await context.datastore.getApiConfig(id, context.orgId);
     if(!config) throw new Error(`api config with id ${id} not found`);
     return config;
 };
@@ -26,7 +26,7 @@ export const getTransformResolver = async (
       throw new Error("id is required");
     }
 
-    const config = await context.datastore.getTransformConfig(id);
+    const config = await context.datastore.getTransformConfig(id, context.orgId);
     if(!config) throw new Error(`transform config with id ${id} not found`);
     return config;
 };
@@ -41,7 +41,7 @@ export const getExtractResolver = async (
       throw new Error("id is required");
     }
 
-    const config = await context.datastore.getExtractConfig(id);
+    const config = await context.datastore.getExtractConfig(id, context.orgId);
     if(!config) throw new Error(`extract config with id ${id} not found`);
     return config;
 };
@@ -55,8 +55,8 @@ export const getRunResolver = async (
   if(!id) {
     throw new Error("id is required");
   }
-  
-  const run = await context.datastore.getRun(id);
+
+  const run = await context.datastore.getRun(id, context.orgId);
   if(!run) throw new Error(`run with id ${id} not found`);
   return run;
 };

--- a/packages/core/graphql/resolvers/list.ts
+++ b/packages/core/graphql/resolvers/list.ts
@@ -1,5 +1,5 @@
-import { GraphQLResolveInfo } from "graphql";
 import { Context } from "@superglue/shared";
+import { GraphQLResolveInfo } from "graphql";
 
 export const listApisResolver = async (
     _: any,
@@ -7,16 +7,17 @@ export const listApisResolver = async (
     context: Context,
     info: GraphQLResolveInfo
   ) => {
-    const result = await context.datastore.listApiConfigs(limit, offset);
+    const result = await context.datastore.listApiConfigs(limit, offset, context.orgId);
     return result;
 };
+
 export const listTransformsResolver = async (
     _: any,
     {offset, limit}: {offset: number, limit: number},
     context: Context,
     info: GraphQLResolveInfo
   ) => {
-    const result = await context.datastore.listTransformConfigs(limit, offset);
+    const result = await context.datastore.listTransformConfigs(limit, offset, context.orgId);
     return result;
 };
 
@@ -26,7 +27,7 @@ export const listExtractsResolver = async (
     context: Context,
     info: GraphQLResolveInfo
   ) => {
-    const result = await context.datastore.listExtractConfigs(limit, offset);
+    const result = await context.datastore.listExtractConfigs(limit, offset, context.orgId);
     return result;
 };
 
@@ -36,6 +37,6 @@ export const listRunsResolver = async (
   context: Context,
   info: GraphQLResolveInfo
 ) => {
-  const result = await context.datastore.listRuns(limit, offset);
+  const result = await context.datastore.listRuns(limit, offset, context.orgId);
   return result;
 };

--- a/packages/core/graphql/resolvers/transform.ts
+++ b/packages/core/graphql/resolvers/transform.ts
@@ -1,9 +1,9 @@
+import { CacheMode, Context, RequestOptions, TransformConfig, TransformInput } from "@superglue/shared";
 import { GraphQLResolveInfo } from "graphql";
-import { CacheMode, Context, TransformConfig, TransformInput, RequestOptions } from "@superglue/shared";
 import { v4 as uuidv4 } from 'uuid';
+import { applyJsonataWithValidation } from "../../utils/tools.js";
 import { prepareTransform } from "../../utils/transform.js";
 import { notifyWebhook } from "../../utils/webhook.js";
-import { applyJsonataWithValidation } from "../../utils/tools.js";
 
 export const transformResolver = async (
   _: any,
@@ -22,7 +22,7 @@ export const transformResolver = async (
   let preparedTransform: TransformConfig | null = null;
   try {
     // Transform response
-    preparedTransform = await prepareTransform(context.datastore, readCache, input, data);
+    preparedTransform = await prepareTransform(context.datastore, readCache, input, data, context.orgId);
     if(!preparedTransform || !preparedTransform.responseMapping) {
       throw new Error("Mapping could not be resolved");
     }
@@ -34,7 +34,7 @@ export const transformResolver = async (
 
     // Save configuration if requested
     if(writeCache) {
-      context.datastore.saveTransformConfig(input, data, preparedTransform);
+      context.datastore.saveTransformConfig(input, data, preparedTransform, context.orgId);
     }
     const completedAt = new Date();
 

--- a/packages/core/graphql/resolvers/upsert.ts
+++ b/packages/core/graphql/resolvers/upsert.ts
@@ -1,5 +1,5 @@
+import { ApiConfig, Context, ExtractConfig, HttpMethod, TransformConfig } from "@superglue/shared";
 import { GraphQLResolveInfo } from "graphql";
-import { ApiConfig, Context, TransformConfig, ExtractConfig, HttpMethod } from "@superglue/shared";
 
 export const upsertApiResolver = async (
     _: any,
@@ -11,7 +11,7 @@ export const upsertApiResolver = async (
       throw new Error("id is required");
     }
     // override id with the id from the input
-    const oldConfig = await context.datastore.getApiConfig(id);
+    const oldConfig = await context.datastore.getApiConfig(id, context.orgId);
 
     // reset the response mapping if there are major updates
     let newResponseMapping = input.responseMapping;
@@ -45,7 +45,7 @@ export const upsertApiResolver = async (
       dataPath: input.dataPath || oldConfig?.dataPath,
       version: input.version || oldConfig?.version
     };
-    await context.datastore.upsertApiConfig(id, config);
+    await context.datastore.upsertApiConfig(id, config, context.orgId);
     return config;
 };
 
@@ -58,7 +58,7 @@ export const upsertTransformResolver = async (
     if(!id) {
       throw new Error("id is required");
     }
-    const oldConfig = await context.datastore.getTransformConfig(id);
+    const oldConfig = await context.datastore.getTransformConfig(id, context.orgId);
     const config = { 
       id: id,
       updatedAt: new Date(),
@@ -66,7 +66,7 @@ export const upsertTransformResolver = async (
       responseSchema: input.responseSchema || oldConfig?.responseSchema || {},
       responseMapping: input.responseMapping || oldConfig?.responseMapping || "",
     };
-    await context.datastore.upsertTransformConfig(id, config);
+    await context.datastore.upsertTransformConfig(id, config, context.orgId);
     return config;
 };
 
@@ -79,7 +79,7 @@ export const upsertExtractResolver = async (
     if(!id) {
       throw new Error("id is required");
     }
-    const oldConfig = await context.datastore.getExtractConfig(id);
+    const oldConfig = await context.datastore.getExtractConfig(id, context.orgId);
     const config = { 
       id: id,
       method: input.method || oldConfig?.method || HttpMethod.GET,
@@ -97,6 +97,6 @@ export const upsertExtractResolver = async (
       fileType: input.fileType || oldConfig?.fileType,
       dataPath: input.dataPath || oldConfig?.dataPath
     };
-    await context.datastore.upsertExtractConfig(id, config);
+    await context.datastore.upsertExtractConfig(id, config, context.orgId);
     return config;
   };

--- a/packages/core/utils/api.ts
+++ b/packages/core/utils/api.ts
@@ -190,7 +190,6 @@ ${lastError ? `We tried it before, but it failed with the following error: ${las
       }
     ]
   });
-  console.log(completion.choices[0].message.content);
   const generatedConfig = JSON.parse(completion.choices[0].message.content);
 
   // Check for any {var} in the generated config that isn't in available variables

--- a/packages/core/utils/transform.test.ts
+++ b/packages/core/utils/transform.test.ts
@@ -1,9 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { prepareTransform, generateMapping } from './transform.js';
-import { DataStore, TransformInput } from '@superglue/shared';
+import { TransformInput } from '@superglue/shared';
 import dotenv from 'dotenv';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { applyJsonataWithValidation } from './tools.js';
-import OpenAI from 'openai/index.mjs';
+import { generateMapping, prepareTransform } from './transform.js';
 
 // Define mockOpenAI at the top level
 const mockOpenAI = {
@@ -31,6 +30,7 @@ describe('transform utils', () => {
   });
 
   describe('prepareTransform', () => {
+    const testOrgId = 'test-org';
     const sampleInput: TransformInput = {
       instruction: 'get the full name from the user',
       responseSchema: {
@@ -52,7 +52,7 @@ describe('transform utils', () => {
         getTransformConfigFromRequest: vi.fn(),
       } as any;      
       const input = { ...sampleInput, responseSchema: {} };
-      const result = await prepareTransform(mockDataStore, false, input, {});
+      const result = await prepareTransform(mockDataStore, false, input, {}, testOrgId);
       expect(result).toBeNull();
     });
 
@@ -69,7 +69,7 @@ describe('transform utils', () => {
       
       (mockDataStore.getTransformConfigFromRequest as any).mockResolvedValue(cachedConfig);
       
-      const result = await prepareTransform(mockDataStore, true, sampleInput, { product: { name: 'test' } });
+      const result = await prepareTransform(mockDataStore, true, sampleInput, { product: { name: 'test' } }, testOrgId);
       
       expect(result).toEqual({
         ...cachedConfig,
@@ -86,7 +86,7 @@ describe('transform utils', () => {
         responseMapping: 'test-mapping'
       };
       
-      const result = await prepareTransform(mockDataStore, false, input, { product: { name: 'test' } });
+      const result = await prepareTransform(mockDataStore, false, input, { product: { name: 'test' } }, testOrgId);
       
       expect(result).toMatchObject({
         responseMapping: 'test-mapping',
@@ -113,7 +113,7 @@ describe('transform utils', () => {
               }
             }]
           });    
-      const transform = await prepareTransform(mockDataStore, false, sampleInput, samplePayload);
+      const transform = await prepareTransform(mockDataStore, false, sampleInput, samplePayload, testOrgId);
       const result = await applyJsonataWithValidation(samplePayload, transform.responseMapping, sampleInput.responseSchema);
       expect(result).toMatchObject({
         success: true,

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -17,4 +17,9 @@ export default defineConfig({
       ],
     },
   },
+  envDir: '../../',
+  esbuild: false,
+  build: {
+    sourcemap: true,
+  }
 })

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -18,7 +18,6 @@ export default defineConfig({
     },
   },
   envDir: '../../',
-  esbuild: false,
   build: {
     sourcemap: true,
   }

--- a/packages/shared/datastore.ts
+++ b/packages/shared/datastore.ts
@@ -1,37 +1,38 @@
-import { ApiConfig, ApiInput, ApiInputRequest, ExtractConfig, ExtractInput, RunResult, TransformConfig, TransformInput } from "./types.js";
+import { ApiConfig, ApiInput, ExtractConfig, ExtractInput, RunResult, TransformConfig, TransformInput } from "./types.js";
 
 
 export interface DataStore {
     // API Config Methods
-    getApiConfig(id: string): Promise<ApiConfig | null>;
-    listApiConfigs(limit?: number, offset?: number): Promise<{ items: ApiConfig[], total: number }>;
-    upsertApiConfig(id: string, config: ApiConfig): Promise<ApiConfig>;
-    deleteApiConfig(id: string): Promise<boolean>;
+    getApiConfig(id: string, orgId?: string): Promise<ApiConfig | null>;
+    listApiConfigs(limit?: number, offset?: number, orgId?: string): Promise<{ items: ApiConfig[], total: number }>;
+    upsertApiConfig(id: string, config: ApiConfig, orgId?: string): Promise<ApiConfig>;
+    deleteApiConfig(id: string, orgId?: string): Promise<void>;
     
-    getApiConfigFromRequest(request: ApiInput, payload: any): Promise<ApiConfig | null>;
-    getTransformConfigFromRequest(request: TransformInput, payload: any): Promise<TransformConfig | null>;
-    getExtractConfigFromRequest(request: ExtractInput, payload: any): Promise<ExtractConfig | null>;
+    getApiConfigFromRequest(request: ApiInput, payload: any, orgId?: string): Promise<ApiConfig | null>;
+    getTransformConfigFromRequest(request: TransformInput, payload: any, orgId?: string): Promise<TransformConfig | null>;
+    getExtractConfigFromRequest(request: ExtractInput, payload: any, orgId?: string): Promise<ExtractConfig | null>;
 
-    saveApiConfig(request: ApiInput, payload: any, config: ApiConfig): Promise<ApiConfig>;
-    saveExtractConfig(request: ExtractInput, payload: any, config: ExtractConfig): Promise<ExtractConfig>;
-    saveTransformConfig(request: TransformInput, payload: any, config: TransformConfig): Promise<TransformConfig>;
+    saveApiConfig(request: ApiInput, payload: any, config: ApiConfig, orgId?: string): Promise<ApiConfig>;
+    saveExtractConfig(request: ExtractInput, payload: any, config: ExtractConfig, orgId?: string): Promise<ExtractConfig>;
+    saveTransformConfig(request: TransformInput, payload: any, config: TransformConfig, orgId?: string): Promise<TransformConfig>;
 
     // Extract Config Methods
-    getExtractConfig(id: string): Promise<ExtractConfig | null>;
-    listExtractConfigs(limit?: number, offset?: number): Promise<{ items: ExtractConfig[], total: number }>;
-    upsertExtractConfig(id: string, config: ExtractConfig): Promise<ExtractConfig>;
-    deleteExtractConfig(id: string): Promise<boolean>;
+    getExtractConfig(id: string, orgId?: string): Promise<ExtractConfig | null>;
+    listExtractConfigs(limit?: number, offset?: number, orgId?: string): Promise<{ items: ExtractConfig[], total: number }>;
+    upsertExtractConfig(id: string, config: ExtractConfig, orgId?: string): Promise<ExtractConfig>;
+    deleteExtractConfig(id: string, orgId?: string): Promise<void>;
   
     // Transform Config Methods
-    getTransformConfig(id: string): Promise<TransformConfig | null>;
-    listTransformConfigs(limit?: number, offset?: number): Promise<{ items: TransformConfig[], total: number }>;
-    upsertTransformConfig(id: string, config: TransformConfig): Promise<TransformConfig>;
-    deleteTransformConfig(id: string): Promise<boolean>;
+    getTransformConfig(id: string, orgId?: string): Promise<TransformConfig | null>;
+    listTransformConfigs(limit?: number, offset?: number, orgId?: string): Promise<{ items: TransformConfig[], total: number }>;
+    upsertTransformConfig(id: string, config: TransformConfig, orgId?: string): Promise<TransformConfig>;
+    deleteTransformConfig(id: string, orgId?: string): Promise<void>;
   
     // Run Result Methods
-    getRun(id: string): Promise<RunResult | null>;
-    listRuns(limit?: number, offset?: number): Promise<{ items: RunResult[], total: number }>;
-    createRun(result: RunResult): Promise<RunResult>;
-    deleteRun(id: string): Promise<boolean>;
+    getRun(id: string, orgId?: string): Promise<RunResult | null>;
+    listRuns(limit?: number, offset?: number, orgId?: string): Promise<{ items: RunResult[], total: number }>;
+    createRun(result: RunResult, orgId?: string): Promise<RunResult>;
+    deleteRun(id: string, orgId?: string): Promise<void>;
+    deleteAllRuns(orgId?: string): Promise<void>;
   }
   

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -3,6 +3,7 @@ import { DataStore } from "./datastore.js";
 
 export type Context = {
   datastore: DataStore;
+  orgId: string;
 };
 
 export enum HttpMethod {


### PR DESCRIPTION
feat: Add multi-tenant support with organization-based data isolation

- Introduce ApiKeyManager interface and implementations (Supabase, Local)
- Add orgId to all DataStore operations for data isolation
- Update resolvers and utilities to pass orgId through context
- Modify storage key structure to include orgId prefix
- Add tests for new authentication and multi-tenant functionality
- Update memory and redis stores to handle organization-scoped data