### PR TITLE
feat: add multi-tenant support with organization IDs

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -22,14 +22,14 @@ jobs:
       with:
         node-version: '20.x'
         cache: 'npm'
-        
-    - name: Debug Redis connection
-      run: |
-        echo "Testing Redis connection..."
-        nc -zv $VITE_REDIS_HOST $VITE_REDIS_PORT
-        
+                
     - name: Install dependencies
       run: npm ci
       
     - name: Run tests
-      run: npm run test
+      run: |
+        VITE_REDIS_HOST=$VITE_REDIS_HOST \
+        VITE_REDIS_PORT=$VITE_REDIS_PORT \
+        VITE_REDIS_USERNAME=$VITE_REDIS_USERNAME \
+        VITE_REDIS_PASSWORD=$VITE_REDIS_PASSWORD \
+        npm run test

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -23,12 +23,10 @@ jobs:
         node-version: '20.x'
         cache: 'npm'
         
-    - name: Debug environment variables
+    - name: Debug Redis connection
       run: |
-        if [ -n "$VITE_REDIS_HOST" ]; then echo "VITE_REDIS_HOST is set"; else echo "VITE_REDIS_HOST is not set"; fi
-        if [ -n "$VITE_REDIS_PORT" ]; then echo "VITE_REDIS_PORT is set"; else echo "VITE_REDIS_PORT is not set"; fi
-        if [ -n "$VITE_REDIS_USERNAME" ]; then echo "VITE_REDIS_USERNAME is set"; else echo "VITE_REDIS_USERNAME is not set"; fi
-        if [ -n "$VITE_REDIS_PASSWORD" ]; then echo "VITE_REDIS_PASSWORD is set"; else echo "VITE_REDIS_PASSWORD is not set"; fi
+        echo "Testing Redis connection..."
+        nc -zv $VITE_REDIS_HOST $VITE_REDIS_PORT
         
     - name: Install dependencies
       run: npm ci

--- a/api.graphql
+++ b/api.graphql
@@ -218,7 +218,7 @@ input TransformInputRequest @oneOf {
 }
 
 type Query {
-  listRuns(limit: Int = 10, offset: Int = 0): RunList!
+  listRuns(limit: Int = 10, offset: Int = 0, configId: ID): RunList!
   listApis(limit: Int = 10, offset: Int = 0): ApiList!
   listTransforms(limit: Int = 10, offset: Int = 0): TransformList!
   listExtracts(limit: Int = 10, offset: Int = 0): ExtractList!

--- a/docs/guides/self-hosting.md
+++ b/docs/guides/self-hosting.md
@@ -147,22 +147,21 @@ Expected response: `OK`
 - **Dashboard**: `http://localhost:3001/`
 - **GraphQL Playground**: `http://localhost:3000/graphql`
 
-## Security Considerations
+## Other Considerations
 
 1. **Network Security**
    - Use reverse proxy (nginx/traefik) for TLS termination
    - Implement IP whitelisting if needed
-   - Keep ports 3000 and 3001 private unless necessary
+   - Keep access to the dashboard private since it is not protected by auth, or implement nginx basic auth to protect it
 
 2. **Authentication**
    - Change default AUTH_TOKEN
    - Use strong Redis passwords
    - Rotate credentials regularly
 
-3. **Rate Limiting**
-   - Configure `RATE_LIMIT_REQUESTS` appropriately
-   - Monitor usage patterns
-   - Implement additional rate limiting at proxy level if needed
+3. **Telemetry**
+   - Superglue uses telemetry to understand how many users are using the platform.
+   - You can opt out by setting the DISABLE_TELEMETRY environment variable to true.
 
 ## Performance Tuning
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
       ],
       "dependencies": {
         "@superglue/client": "^2.3.4",
-        "@superglue/core": "file:packages/core",
-        "@superglue/shared": "file:packages/shared",
-        "@superglue/web": "file:packages/web",
         "dotenv": "^16.4.7",
         "dotenv-cli": "^8.0.0"
       },
@@ -9978,7 +9975,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@apollo/server": "^4.11.2",
-        "@superglue/shared": "file:../shared",
         "axios": "^1.7.9",
         "console-stamp": "^3.1.2",
         "cors": "^2.8.5",
@@ -10027,6 +10023,9 @@
         "@types/node": "^20.0.0",
         "typescript": "^5.0.0"
       }
+    },
+    "packages/shared/src": {
+      "extraneous": true
     },
     "packages/web": {
       "name": "@superglue/web",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@superglue/client": "^2.3.4",
         "@superglue/core": "file:packages/core",
         "@superglue/shared": "file:packages/shared",
         "@superglue/web": "file:packages/web",
@@ -3299,6 +3300,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@superglue/client": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@superglue/client/-/client-2.3.4.tgz",
+      "integrity": "sha512-k4krWRLbwulguue1kg1c5uAIj/xU459imCz+6UpA5y7tXJ9ytMkA4gOf7uTrNg8NspQjUYB7+o6iqSV0t+Urxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "axios": "^1.7.9"
+      }
+    },
     "node_modules/@superglue/core": {
       "resolved": "packages/core",
       "link": true
@@ -3306,15 +3316,6 @@
     "node_modules/@superglue/shared": {
       "resolved": "packages/shared",
       "link": true
-    },
-    "node_modules/@superglue/superglue": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@superglue/superglue/-/superglue-2.3.1.tgz",
-      "integrity": "sha512-jM97bfgFH19p0gBd6xv8bfaNO2lMMQc9MAmkrvdrxuQ3uWgnXyBV4EGOhJYNu7O95IgKv0HRgcqs3HrA8QYz0g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "axios": "^1.7.9"
-      }
     },
     "node_modules/@superglue/web": {
       "resolved": "packages/web",
@@ -10043,7 +10044,6 @@
         "@radix-ui/react-toast": "^1.2.5",
         "@radix-ui/react-tooltip": "^1.1.7",
         "@superglue/shared": "file:../shared",
-        "@superglue/superglue": "^2.2.0",
         "autoprefixer": "^10.4.20",
         "axios": "^1.7.9",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
   },
   "dependencies": {
     "@superglue/client": "^2.3.4",
-    "@superglue/core": "file:packages/core",
-    "@superglue/shared": "file:packages/shared",
-    "@superglue/web": "file:packages/web",
     "dotenv": "^16.4.7",
     "dotenv-cli": "^8.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
     "clean": "turbo run clean"
   },
   "dependencies": {
+    "@superglue/client": "^2.3.4",
+    "@superglue/core": "file:packages/core",
     "@superglue/shared": "file:packages/shared",
     "@superglue/web": "file:packages/web",
-    "@superglue/core": "file:packages/core",
     "dotenv": "^16.4.7",
     "dotenv-cli": "^8.0.0"
   },

--- a/packages/core/auth/supabaseKeyManager.test.ts
+++ b/packages/core/auth/supabaseKeyManager.test.ts
@@ -7,7 +7,7 @@ describe('SupabaseKeyManager', () => {
   const mockEnv = {
     NEXT_PUBLIC_SUPABASE_URL: 'http://test.com',
     NEXT_PUBLIC_SUPABASE_ANON_KEY: 'test-anon-key',
-    NEXT_PUBLIC_PRIV_SUPABASE_SERVICE_ROLE_KEY: 'test-service-key'
+    PRIV_SUPABASE_SERVICE_ROLE_KEY: 'test-service-key'
   };
   let keyManager: SupabaseKeyManager;
 

--- a/packages/core/auth/supabaseKeyManager.ts
+++ b/packages/core/auth/supabaseKeyManager.ts
@@ -15,19 +15,17 @@ export class SupabaseKeyManager implements ApiKeyManager {
   }
 
   public async getApiKeys(): Promise<{ orgId: string; key: string }[]> {
-    // Check cache first
-    if (this.cachedApiKeys.length > 0) {
-      return this.cachedApiKeys;
-    }
-
-    // If cache is empty or expired, refresh the keys
-    await this.refreshApiKeys();
     return this.cachedApiKeys;
   }
 
   public async authenticate(apiKey: string): Promise<{ orgId: string; success: boolean }> {
-    const keys = await this.getApiKeys();
-    const key = keys.find(k => k.key === apiKey);
+    let keys = await this.getApiKeys();
+    let key = keys.find(k => k.key === apiKey);
+    if (!key) {
+      await this.refreshApiKeys();
+      keys = await this.getApiKeys();
+      key = keys.find(k => k.key === apiKey);
+    }
     return { orgId: key?.orgId || '', success: !!key };
   }
 

--- a/packages/core/auth/supabaseKeyManager.ts
+++ b/packages/core/auth/supabaseKeyManager.ts
@@ -64,9 +64,6 @@ export class SupabaseKeyManager implements ApiKeyManager {
 
   private async refreshApiKeys(): Promise<void> {
     try {
-      if (Date.now() - this.lastFetchTime < this.API_KEY_CACHE_TTL) {
-        return;
-      }
       this.cachedApiKeys = await this.fetchApiKeys();
       this.lastFetchTime = Date.now();
     } catch (error) {

--- a/packages/core/auth/supabaseKeyManager.ts
+++ b/packages/core/auth/supabaseKeyManager.ts
@@ -34,7 +34,7 @@ export class SupabaseKeyManager implements ApiKeyManager {
   private async fetchApiKeys(): Promise<{ orgId: string; key: string }[]> {
     const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-    const SUPABASE_SERVICE_ROLE_KEY = process.env.NEXT_PUBLIC_PRIV_SUPABASE_SERVICE_ROLE_KEY;
+    const SUPABASE_SERVICE_ROLE_KEY = process.env.PRIV_SUPABASE_SERVICE_ROLE_KEY;
 
     if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !SUPABASE_SERVICE_ROLE_KEY) {
       console.error('Missing required Supabase environment variables');

--- a/packages/core/datastore/memory.test.ts
+++ b/packages/core/datastore/memory.test.ts
@@ -150,7 +150,7 @@ describe('MemoryStore', () => {
       await store.createRun(run1, testOrgId);
       await store.createRun(run2, testOrgId);
 
-      const { items, total } = await store.listRuns(10, 0, testOrgId);
+      const { items, total } = await store.listRuns(10, 0, null, testOrgId);
       expect(items).toHaveLength(2);
       expect(total).toBe(2);
       expect(items[0].id).toBe(run2.id); // Most recent first
@@ -169,11 +169,11 @@ describe('MemoryStore', () => {
       const run2 = { ...testRun, id: 'run2', config: { ...testRun.config, id: 'config2' } };
       const run3 = { ...testRun, id: 'run3', config: { ...testRun.config, id: 'config1' } };
       
-      await store.createRun(run1);
-      await store.createRun(run2);
-      await store.createRun(run3);
+      await store.createRun(run1, testOrgId);
+      await store.createRun(run2, testOrgId);
+      await store.createRun(run3, testOrgId);
       
-      const { items, total } = await store.listRuns(10, 0, 'config1');
+      const { items, total } = await store.listRuns(10, 0, 'config1', testOrgId);
       expect(items.length).toBe(2);
       expect(total).toBe(3); // Total is still all runs
       expect(items.map(run => run.id).sort()).toEqual(['run1', 'run3']);
@@ -191,14 +191,14 @@ describe('MemoryStore', () => {
         config: { ...testRun.config, id: 'config1' } 
       };
       
-      await store.createRun(runWithoutConfigId);
-      await store.createRun(runWithConfigId);
+      await store.createRun(runWithoutConfigId, testOrgId);
+      await store.createRun(runWithConfigId, testOrgId);
       
-      const { items: filteredItems } = await store.listRuns(10, 0, 'config1');
+      const { items: filteredItems } = await store.listRuns(10, 0, 'config1', testOrgId);
       expect(filteredItems.length).toBe(1);
       expect(filteredItems[0].id).toBe('run2');
 
-      const { items: allItems } = await store.listRuns(10, 0);
+      const { items: allItems } = await store.listRuns(10, 0, null, testOrgId);
       expect(allItems.length).toBe(2);
     });
   });
@@ -253,7 +253,7 @@ describe('MemoryStore', () => {
       const { total: apiTotal } = await store.listApiConfigs(10, 0, testOrgId);
       const { total: extractTotal } = await store.listExtractConfigs(10, 0, testOrgId);
       const { total: transformTotal } = await store.listTransformConfigs(10, 0, testOrgId);
-      const { total: runTotal } = await store.listRuns(10, 0, testOrgId);
+      const { total: runTotal } = await store.listRuns(10, 0, null, testOrgId);
 
       expect(apiTotal).toBe(0);
       expect(extractTotal).toBe(0);

--- a/packages/core/datastore/memory.test.ts
+++ b/packages/core/datastore/memory.test.ts
@@ -163,6 +163,44 @@ describe('MemoryStore', () => {
       const retrieved = await store.getRun(testRun.id, testOrgId);
       expect(retrieved).toBeNull();
     });
+
+    it('should list runs filtered by config ID', async () => {
+      const run1 = { ...testRun, id: 'run1', config: { ...testRun.config, id: 'config1' } };
+      const run2 = { ...testRun, id: 'run2', config: { ...testRun.config, id: 'config2' } };
+      const run3 = { ...testRun, id: 'run3', config: { ...testRun.config, id: 'config1' } };
+      
+      await store.createRun(run1);
+      await store.createRun(run2);
+      await store.createRun(run3);
+      
+      const { items, total } = await store.listRuns(10, 0, 'config1');
+      expect(items.length).toBe(2);
+      expect(total).toBe(3); // Total is still all runs
+      expect(items.map(run => run.id).sort()).toEqual(['run1', 'run3']);
+    });
+
+    it('should handle listing runs when configs have missing IDs', async () => {
+      const runWithoutConfigId = { 
+        ...testRun, 
+        id: 'run1', 
+        config: { ...testRun.config, id: undefined } 
+      };
+      const runWithConfigId = { 
+        ...testRun, 
+        id: 'run2', 
+        config: { ...testRun.config, id: 'config1' } 
+      };
+      
+      await store.createRun(runWithoutConfigId);
+      await store.createRun(runWithConfigId);
+      
+      const { items: filteredItems } = await store.listRuns(10, 0, 'config1');
+      expect(filteredItems.length).toBe(1);
+      expect(filteredItems[0].id).toBe('run2');
+
+      const { items: allItems } = await store.listRuns(10, 0);
+      expect(allItems.length).toBe(2);
+    });
   });
 
   describe('Clear All', () => {

--- a/packages/core/datastore/memory.ts
+++ b/packages/core/datastore/memory.ts
@@ -174,7 +174,7 @@ export class MemoryStore implements DataStore {
     return run;
   }
 
-  async listRuns(limit: number = 10, offset: number = 0, orgId: string, configId?: string): Promise<{ items: RunResult[], total: number }> {
+  async listRuns(limit: number = 10, offset: number = 0, configId?: string, orgId?: string): Promise<{ items: RunResult[], total: number }> {
     const index = this.storage.runsIndex.get(orgId) || [];
     const runIds = index
       .filter(entry => !configId || entry.configId === configId)
@@ -190,7 +190,7 @@ export class MemoryStore implements DataStore {
     return { items, total: index.length };
   }
 
-  async deleteRun(id: string, orgId: string): Promise<void> {
+  async deleteRun(id: string, orgId: string): Promise<boolean> {
     const key = this.getKey('run', id, orgId);
     const deleted = this.storage.runs.delete(key);
     
@@ -201,6 +201,7 @@ export class MemoryStore implements DataStore {
         index.splice(entryIndex, 1);
       }
     }
+    return deleted;
   }
 
   async deleteAllRuns(orgId: string): Promise<void> {

--- a/packages/core/datastore/redis.test.ts
+++ b/packages/core/datastore/redis.test.ts
@@ -15,12 +15,21 @@ describe('RedisService', () => {
   const testOrgId = 'test-org';
 
   beforeEach(async () => {
-    store = new RedisService(testConfig);
-    await store.clearAll(testOrgId); 
+    try {
+      store = new RedisService(testConfig);
+      await store.clearAll(testOrgId);
+    } catch (error) {
+      console.error('Failed to connect to Redis:', error);
+      throw error;
+    }
   });
 
   afterEach(async () => {
-    await store.disconnect();
+    try {
+      await store.disconnect();
+    } catch (error) {
+      console.error('Failed to disconnect from Redis:', error);
+    }
   });
 
   describe('API Config', () => {

--- a/packages/core/datastore/redis.test.ts
+++ b/packages/core/datastore/redis.test.ts
@@ -172,11 +172,11 @@ describe('RedisService', () => {
       await store.createRun(run1, testOrgId);
       await store.createRun(run2, testOrgId);
 
-      const { items, total } = await store.listRuns(10, 0, testOrgId);
+      const { items, total } = await store.listRuns(10, 0, null, testOrgId);
       expect(items).toHaveLength(2);
       expect(total).toBe(2);
-      expect(items[0].id).toBe(run1.id); // Most recent first
-      expect(items[1].id).toBe(run2.id);
+      expect(items[0].id).toBe(run2.id); // Most recent first
+      expect(items[1].id).toBe(run1.id);
     });
 
     it('should delete runs', async () => {
@@ -189,7 +189,7 @@ describe('RedisService', () => {
     it('should delete all runs', async () => {
       await store.createRun(testRun, testOrgId);
       await store.deleteAllRuns(testOrgId);
-      const { items, total } = await store.listRuns(10, 0, testOrgId);
+      const { items, total } = await store.listRuns(10, 0, null, testOrgId);
       expect(items).toHaveLength(0);
       expect(total).toBe(0);
     });

--- a/packages/core/graphql/resolvers/list.ts
+++ b/packages/core/graphql/resolvers/list.ts
@@ -37,6 +37,6 @@ export const listRunsResolver = async (
   context: Context,
   info: GraphQLResolveInfo
 ) => {
-  const result = await context.datastore.listRuns(limit, offset, context.orgId, configId);
+  const result = await context.datastore.listRuns(limit, offset, configId, context.orgId);
   return result;
 };

--- a/packages/core/graphql/resolvers/list.ts
+++ b/packages/core/graphql/resolvers/list.ts
@@ -33,10 +33,10 @@ export const listExtractsResolver = async (
 
 export const listRunsResolver = async (
   _: any,
-  {offset, limit}: {offset: number, limit: number},
+  {offset, limit, configId}: {offset: number, limit: number, configId: string},
   context: Context,
   info: GraphQLResolveInfo
 ) => {
-  const result = await context.datastore.listRuns(limit, offset, context.orgId);
+  const result = await context.datastore.listRuns(limit, offset, context.orgId, configId);
   return result;
 };

--- a/packages/core/graphql/resolvers/upsert.ts
+++ b/packages/core/graphql/resolvers/upsert.ts
@@ -27,13 +27,13 @@ export const upsertApiResolver = async (
     }
 
     const config = { 
-      method: input.method || oldConfig?.method || HttpMethod.GET,
       urlHost: input.urlHost || oldConfig?.urlHost || '',
       urlPath: input.urlPath || oldConfig?.urlPath || '',
       instruction: input.instruction || oldConfig?.instruction || '',
       createdAt: input.createdAt || oldConfig?.createdAt || new Date(),
       updatedAt: new Date(),
       id: id,
+      method: input.method || oldConfig?.method,
       queryParams: input.queryParams || oldConfig?.queryParams,
       headers: input.headers || oldConfig?.headers,
       body: input.body || oldConfig?.body,
@@ -82,12 +82,12 @@ export const upsertExtractResolver = async (
     const oldConfig = await context.datastore.getExtractConfig(id, context.orgId);
     const config = { 
       id: id,
-      method: input.method || oldConfig?.method || HttpMethod.GET,
       urlHost: input.urlHost || oldConfig?.urlHost || '',
       urlPath: input.urlPath || oldConfig?.urlPath || '',
       instruction: input.instruction || oldConfig?.instruction || '',
       createdAt: oldConfig?.createdAt || new Date(),
       updatedAt: new Date(),
+      method: input.method || oldConfig?.method,
       queryParams: input.queryParams || oldConfig?.queryParams,
       headers: input.headers || oldConfig?.headers,
       body: input.body || oldConfig?.body,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,6 @@
   },
   "type": "module",
   "dependencies": {
-    "@superglue/shared": "file:../shared",
     "@apollo/server": "^4.11.2",
     "axios": "^1.7.9",
     "console-stamp": "^3.1.2",

--- a/packages/core/utils/api.ts
+++ b/packages/core/utils/api.ts
@@ -146,7 +146,7 @@ async function generateApiConfig(apiConfig: Partial<ApiConfig>, documentation: s
     queryParams: z.record(z.any()).optional(),
     method: z.enum(Object.values(HttpMethod) as [string, ...string[]]),
     headers: z.record(z.string()).optional(),
-    body: z.string().optional(),
+    body: z.string().optional().describe("Format as JSON if not instructed otherwise."),
     authentication: z.enum(Object.values(AuthType) as [string, ...string[]]),
     dataPath: z.string().optional().describe("The path to the data you want to extract from the response. E.g. products.variants.size"),
     pagination: z.object({

--- a/packages/core/utils/api.ts
+++ b/packages/core/utils/api.ts
@@ -181,7 +181,7 @@ Instructions: ${apiConfig.instruction}
 
 Base URL: ${composeUrl(apiConfig.urlHost, apiConfig.urlPath)}
 
-Documentation: ${String(documentation).slice(0, lastError ? 20000 : 10000)}
+Documentation: ${String(documentation).slice(0, 10000)}
 
 Available variables: ${vars.join(", ")}
 

--- a/packages/core/utils/prompts.ts
+++ b/packages/core/utils/prompts.ts
@@ -98,4 +98,8 @@ export const API_PROMPT = `You are an API configuration assistant. Generate API 
       e.g. headers: {
         "X-Page": "{page}"
       }
+- to insert arrays, use the following format:
+  e.g. body: {
+    "items": {items}
+  }
 `;

--- a/packages/core/utils/telemetry.ts
+++ b/packages/core/utils/telemetry.ts
@@ -15,19 +15,28 @@ export const telemetryClient = !isTelemetryDisabled && !isDebug ?
     { host: config.posthog.host }
   ) : null;
 
+if(telemetryClient) {
+  console.log("superglue uses telemetry to understand how many users are using the platform. See self-hosting guide for more info.");
+}
+
 export const telemetryMiddleware = (req, res, next) => {
+  if(!telemetryClient) {
+    return next();
+  }
+
   if(req?.body?.query && !(req.body.query.includes("IntrospectionQuery") || req.body.query.includes("__schema"))) {
     // we track the query, but NOT the variables or the response
     // the query just contains the superglue endpoint that you call, e.g. "listCalls", 
     // but not which actual endpoint you call or what payload / auth you use
-    telemetryClient?.capture({
-        distinctId: sessionId,
+
+    telemetryClient.capture({
+        distinctId: req.orgId || sessionId,
         event: 'query',
         properties: {
           query: req.body.query
         }
       });
-      }
+    }
   next();
 };
 

--- a/packages/core/utils/tools.ts
+++ b/packages/core/utils/tools.ts
@@ -142,6 +142,10 @@ export function replaceVariables(template: string, variables: Record<string, any
       return match; // Keep original if final value is invalid
     }
 
+    if(Array.isArray(value)) {
+      return JSON.stringify(value);
+    }
+    
     return String(value);
   });
 }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       ],
     },
   },
+  envDir: '../../',
   build: {
     sourcemap: true,
   }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -17,7 +17,6 @@ export default defineConfig({
       ],
     },
   },
-  envDir: '../../',
   build: {
     sourcemap: true,
   }

--- a/packages/shared/datastore.ts
+++ b/packages/shared/datastore.ts
@@ -30,9 +30,9 @@ export interface DataStore {
   
     // Run Result Methods
     getRun(id: string, orgId?: string): Promise<RunResult | null>;
-    listRuns(limit?: number, offset?: number, orgId?: string, configId?: string): Promise<{ items: RunResult[], total: number }>;
+    listRuns(limit?: number, offset?: number, configId?: string, orgId?: string): Promise<{ items: RunResult[], total: number }>;
     createRun(result: RunResult, orgId?: string): Promise<RunResult>;
-    deleteRun(id: string, orgId?: string): Promise<void>;
+    deleteRun(id: string, orgId?: string): Promise<boolean>;
     deleteAllRuns(orgId?: string): Promise<void>;
   }
   

--- a/packages/shared/datastore.ts
+++ b/packages/shared/datastore.ts
@@ -30,7 +30,7 @@ export interface DataStore {
   
     // Run Result Methods
     getRun(id: string, orgId?: string): Promise<RunResult | null>;
-    listRuns(limit?: number, offset?: number, orgId?: string): Promise<{ items: RunResult[], total: number }>;
+    listRuns(limit?: number, offset?: number, orgId?: string, configId?: string): Promise<{ items: RunResult[], total: number }>;
     createRun(result: RunResult, orgId?: string): Promise<RunResult>;
     deleteRun(id: string, orgId?: string): Promise<void>;
     deleteAllRuns(orgId?: string): Promise<void>;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,7 +21,6 @@
         "@radix-ui/react-toast": "^1.2.5",
         "@radix-ui/react-tooltip": "^1.1.7",
         "@superglue/shared": "file:../shared",
-        "@superglue/superglue": "^2.2.0",
         "autoprefixer": "^10.4.20",
         "axios": "^1.7.9",
         "class-variance-authority": "^0.7.1",

--- a/packages/web/src/app/client-layout.tsx
+++ b/packages/web/src/app/client-layout.tsx
@@ -1,12 +1,12 @@
 "use client"
 import { usePathname } from 'next/navigation'
-import { ConfigProvider } from './config-context'
-import { Sidebar } from '../components/Sidebar'
-import { CSPostHogProvider } from './providers'
+import { ConfigProvider } from '@/src/app/config-context'
+import { Sidebar } from '@/src/components/Sidebar'
+import { CSPostHogProvider } from '@/src/app/providers'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Toaster } from '../components/ui/toaster'
-import { ServerMonitor } from '../components/ServerMonitor'
-import { geistSans, geistMono } from './fonts'
+import { Toaster } from '@/src/components/ui/toaster'
+import { ServerMonitor } from '@/src/components/ServerMonitor'
+import { geistSans, geistMono } from '@/src/app/fonts'
 
 export function ClientWrapper({ children, config }: { children: React.ReactNode, config: any }) {
   const pathname = usePathname() 

--- a/packages/web/src/app/configs/[id]/page.tsx
+++ b/packages/web/src/app/configs/[id]/page.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/src/components/ui/accordion";
 import { composeUrl } from '@/src/lib/utils';
 import { ApiConfig } from '@superglue/shared';
-import { useConfig } from '../../config-context';
+import { useConfig } from '@/src/app/config-context';
 import { SuperglueClient } from '@superglue/superglue';
 
 const ApiConfigDetail = ({ id, onClose }: { id?: string; onClose?: () => void }) => {

--- a/packages/web/src/app/configs/[id]/page.tsx
+++ b/packages/web/src/app/configs/[id]/page.tsx
@@ -13,7 +13,7 @@ import {
 import { composeUrl } from '@/src/lib/utils';
 import { ApiConfig } from '@superglue/shared';
 import { useConfig } from '@/src/app/config-context';
-import { SuperglueClient } from '@superglue/superglue';
+import { SuperglueClient } from '@superglue/client';
 
 const ApiConfigDetail = ({ id, onClose }: { id?: string; onClose?: () => void }) => {
   const router = useRouter();

--- a/packages/web/src/app/configs/new/page.tsx
+++ b/packages/web/src/app/configs/new/page.tsx
@@ -1,50 +1,8 @@
 'use client'
 
-import React from 'react';
-import { useRouter } from 'next/navigation';
-import { ArrowLeft, Info } from 'lucide-react';
-import { Button } from "@/src/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/src/components/ui/card";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/src/components/ui/select";
-import { Input } from "@/src/components/ui/input";
-import { Label } from "@/src/components/ui/label";
-import { Textarea } from "@/src/components/ui/textarea";
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@/src/components/ui/tabs";
-import JsonSchemaEditor from "@/src/components/JsonSchemaEditor";
-import { ApiConfig, ApiInput, AuthType, CacheMode, HttpMethod, PaginationType } from '@superglue/shared';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from "@/src/components/ui/dialog";
-import { useToast } from "@/src/hooks/use-toast";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/src/components/ui/tooltip";
 import { useConfig } from '@/src/app/config-context';
-import { SuperglueClient } from '@superglue/client';
+import { ApiPlayground } from '@/src/components/apiPlayground';
+import JsonSchemaEditor from "@/src/components/JsonSchemaEditor";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -55,7 +13,49 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/src/components/ui/alert-dialog";
-import { ApiPlayground } from '@/src/components/apiPlayground';
+import { Button } from "@/src/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/src/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/src/components/ui/dialog";
+import { Input } from "@/src/components/ui/input";
+import { Label } from "@/src/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/src/components/ui/select";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/src/components/ui/tabs";
+import { Textarea } from "@/src/components/ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
+import { useToast } from "@/src/hooks/use-toast";
+import { isJsonEmpty } from '@/src/lib/utils';
+import { ApiConfig, ApiInput, AuthType, CacheMode, HttpMethod, PaginationType, SuperglueClient } from '@superglue/client';
+import { ArrowLeft, Info } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import React from 'react';
 
 const HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'];
 const AUTH_TYPES = ['NONE', 'HEADER', 'QUERY_PARAM', 'OAUTH2'];
@@ -222,13 +222,13 @@ const ApiConfigForm = ({ id }: { id?: string }) => {
     // Optional fields
     const optionalFields = {
       urlPath: formData.urlPath,
-      headers: formData.headers ? JSON.parse(formData.headers) : undefined,
-      queryParams: formData.queryParams ? JSON.parse(formData.queryParams) : undefined,
+      headers: isJsonEmpty(formData.headers) ? undefined : JSON.parse(formData.headers),
+      queryParams: isJsonEmpty(formData.queryParams) ? undefined : JSON.parse(formData.queryParams),
       body: formData.body,
       dataPath: formData.dataPath,
       method: formData.method !== "auto" ? formData.method as HttpMethod : undefined,
       authentication: formData.authentication !== "auto" ? formData.authentication as AuthType : undefined,
-      responseSchema: formData.responseSchema ? JSON.parse(formData.responseSchema) : undefined,
+      responseSchema: isJsonEmpty(formData.responseSchema) ? undefined : JSON.parse(formData.responseSchema),
       responseMapping: formData.responseMapping ? String(formData.responseMapping) : undefined,
       documentationUrl: formData.documentationUrl,
       pagination: formData.paginationType !== "auto" ? {

--- a/packages/web/src/app/configs/new/page.tsx
+++ b/packages/web/src/app/configs/new/page.tsx
@@ -44,7 +44,7 @@ import {
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
 import { useConfig } from '@/src/app/config-context';
-import { SuperglueClient } from '@superglue/superglue';
+import { SuperglueClient } from '@superglue/client';
 import {
   AlertDialog,
   AlertDialogAction,

--- a/packages/web/src/app/configs/page.tsx
+++ b/packages/web/src/app/configs/page.tsx
@@ -1,8 +1,7 @@
 "use client"
 
 import React from 'react';
-import { useRouter, usePathname } from 'next/navigation';
-import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import {
   Table,
   TableBody,
@@ -12,17 +11,19 @@ import {
   TableRow,
 } from "@/src/components/ui/table";
 import { Button } from "@/src/components/ui/button";
-import { Plus, Settings, Play } from "lucide-react";
+import { Plus, Settings, Play, History } from "lucide-react";
 import {
   Sheet,
   SheetContent,
   SheetHeader,
   SheetTitle,
 } from "@/src/components/ui/sheet"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/src/components/ui/tooltip"
 import ApiConfigDetail from '@/src/app/configs/[id]/page';
 import { ApiConfig } from '@superglue/shared';
 import { useConfig } from '@/src/app/config-context';
-import { SuperglueClient } from '@superglue/superglue';
+import { SuperglueClient } from '@superglue/client';
+
 const ConfigTable = () => {
   const router = useRouter();
   const [configs, setConfigs] = React.useState<ApiConfig[]>([]);
@@ -69,76 +70,111 @@ const ConfigTable = () => {
     router.push(`/configs/${id}/run`);
   };
 
+  const handleViewLogs = (e: React.MouseEvent, id: string) => {
+    e.stopPropagation();
+    router.push(`/runs/${id}`);
+  };
+
   if (loading) {
     return "";
   }
 
   return (
-    <div className="flex-1 overflow-auto">
-      <div className="p-8">
-        <div className="flex justify-between items-center mb-6">
-          <h1 className="text-2xl font-bold">API Configurations</h1>
-          <Button onClick={handleCreateNew}>
-            <Plus className="mr-2 h-4 w-4" />
-            Create New
-          </Button>
-        </div>
+    <div className="p-8 max-w-none w-full min-h-full">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold">API Configurations</h1>
+        <Button onClick={handleCreateNew}>
+          <Plus className="mr-2 h-4 w-4" />
+          Create New
+        </Button>
+      </div>
 
-        <div className="border rounded-lg">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>ID</TableHead>
-                <TableHead>Instruction</TableHead>
-                <TableHead>URL</TableHead>
-                <TableHead>Method</TableHead>
-                <TableHead>Updated At</TableHead>
-                <TableHead></TableHead>
+      <div className="border rounded-lg">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>Instruction</TableHead>
+              <TableHead>URL</TableHead>
+              <TableHead>Method</TableHead>
+              <TableHead>Updated At</TableHead>
+              <TableHead></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {configs.map((config) => (
+              <TableRow
+                key={config.id}
+                onClick={() => handleRowClick(config)}
+                className="cursor-pointer hover:bg-secondary"
+              >
+                <TableCell className="font-medium max-w-[100px] truncate">
+                  {config.id}
+                </TableCell>
+                <TableCell className="max-w-[300px] truncate">
+                  {config.instruction}
+                </TableCell>
+                <TableCell className="font-medium max-w-[200px] truncate">
+                  {config.urlHost}
+                </TableCell>
+                <TableCell className="w-[100px]">{config.method}</TableCell>
+                <TableCell className="w-[150px]">
+                  {config.updatedAt ? new Date(config.updatedAt).toLocaleDateString() : ''}
+                </TableCell>
+                <TableCell className="w-[100px]">
+                  <div className="flex gap-2">
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={(e) => handlePlay(e, config.id)}
+                          >
+                            <Play className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Run API</p>
+                        </TooltipContent>
+                      </Tooltip>
+
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={(e) => handleViewLogs(e, config.id)}
+                          >
+                            <History className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>View Run History</p>
+                        </TooltipContent>
+                      </Tooltip>
+
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={(e) => handleEdit(e, config.id)}
+                          >
+                            <Settings className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Edit Configuration</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                </TableCell>
               </TableRow>
-            </TableHeader>
-            <TableBody>
-              {configs.map((config) => (
-                <TableRow
-                  key={config.id}
-                  onClick={() => handleRowClick(config)}
-                  className="cursor-pointer hover:bg-secondary"
-                >
-                  <TableCell className="font-medium max-w-[100px] truncate">
-                    {config.id}
-                  </TableCell>
-                  <TableCell className="max-w-[300px] truncate">
-                    {config.instruction}
-                  </TableCell>
-                  <TableCell className="font-medium max-w-[200px] truncate">
-                    {config.urlHost}
-                  </TableCell>
-                  <TableCell className="w-[100px]">{config.method}</TableCell>
-                  <TableCell className="w-[150px]">
-                    {config.updatedAt ? new Date(config.updatedAt).toLocaleDateString() : ''}
-                  </TableCell>
-                  <TableCell className="w-[100px]">
-                    <div className="flex gap-2">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={(e) => handlePlay(e, config.id)}
-                      >
-                        <Play className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={(e) => handleEdit(e, config.id)}
-                      >
-                        <Settings className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+            ))}
+          </TableBody>
+        </Table>
       </div>
 
       <Sheet open={isDetailOpen} onOpenChange={setIsDetailOpen}>

--- a/packages/web/src/app/configs/page.tsx
+++ b/packages/web/src/app/configs/page.tsx
@@ -19,7 +19,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/src/components/ui/sheet"
-import ApiConfigDetail from './[id]/page';
+import ApiConfigDetail from '@/src/app/configs/[id]/page';
 import { ApiConfig } from '@superglue/shared';
 import { useConfig } from '@/src/app/config-context';
 import { SuperglueClient } from '@superglue/superglue';

--- a/packages/web/src/app/configs/page.tsx
+++ b/packages/web/src/app/configs/page.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/src/components/ui/sheet"
 import ApiConfigDetail from './[id]/page';
 import { ApiConfig } from '@superglue/shared';
-import { useConfig } from '../config-context';
+import { useConfig } from '@/src/app/config-context';
 import { SuperglueClient } from '@superglue/superglue';
 const ConfigTable = () => {
   const router = useRouter();

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import "@/src/globals.css";
+import "./globals.css";
 import nextConfig from "@/next.config";
 import { ClientWrapper } from "@/src/app/client-layout";
 import { geistSans, geistMono } from '@/src/app/fonts'

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,7 +1,7 @@
-import "./globals.css";
+import "@/src/globals.css";
 import nextConfig from "@/next.config";
-import { ClientWrapper } from "./client-layout";
-import { geistSans, geistMono } from './fonts'
+import { ClientWrapper } from "@/src/app/client-layout";
+import { geistSans, geistMono } from '@/src/app/fonts'
 
 // we need to force dynamic to get the env vars at runtime
 export const dynamic = 'force-dynamic'

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ConfigTable from './configs/page';
+import ConfigTable from '@/src/app/configs/page';
 
 const Main = () => {
   return (

--- a/packages/web/src/app/runs/[id]/page.tsx
+++ b/packages/web/src/app/runs/[id]/page.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { RunsTable } from "@/src/components/runsTable";
+import { useParams } from "next/navigation";
+import { Button } from "@/src/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+export default function RunsPage() {
+    const { id } = useParams();     
+    const router = useRouter();
+    
+    return (
+        <div className="p-8 max-w-none w-full min-h-full">
+            <Button
+                variant="ghost"
+                onClick={() => router.push('/configs')}
+                className="mb-4"
+            >
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back
+            </Button>
+            <RunsTable id={id as string} />
+        </div>
+    );
+}

--- a/packages/web/src/app/runs/page.tsx
+++ b/packages/web/src/app/runs/page.tsx
@@ -11,7 +11,7 @@ import {
   TableRow,
 } from "@/src/components/ui/table";
 import { RunResult } from '@superglue/shared';
-import { useConfig } from '../config-context';
+import { useConfig } from '@/src/app/config-context';
 import { SuperglueClient } from '@superglue/superglue';
 const RunsTable = () => {
   const router = useRouter();

--- a/packages/web/src/app/runs/page.tsx
+++ b/packages/web/src/app/runs/page.tsx
@@ -1,111 +1,12 @@
 "use client"
 
 import React from 'react';
-import { useRouter } from 'next/navigation';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/src/components/ui/table";
-import { RunResult } from '@superglue/shared';
-import { useConfig } from '@/src/app/config-context';
-import { SuperglueClient } from '@superglue/superglue';
-const RunsTable = () => {
-  const router = useRouter();
-  const [runs, setRuns] = React.useState<RunResult[]>([]);
-  const [loading, setLoading] = React.useState(true);
-  const [currentPage, setCurrentPage] = React.useState(0);
-  const pageSize = 50;
-  const config = useConfig();
+import { RunsTable } from '../../components/runsTable';
 
-  React.useEffect(() => {
-    const getRuns = async () => {
-      try { 
-        const superglueClient = new SuperglueClient({
-          endpoint: config.superglueEndpoint,
-          apiKey: config.superglueApiKey
-        })
-        const data = await superglueClient.listRuns(pageSize, currentPage * pageSize);
-        setRuns(data.items);
-      } catch (error) {
-        console.error('Error fetching runs:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    getRuns();
-  }, [currentPage]);
-
-  if (loading) {
-    return "";
-  }
-
+export default function RunsPage() {
   return (
-    <div className="flex-1 overflow-auto">
-      <div className="p-8">
-        <div className="flex justify-between items-center mb-6">
-          <h1 className="text-2xl font-bold">API Runs</h1>
-        </div>
-
-        <div className="border rounded-lg">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>API Id</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Started At</TableHead>
-                <TableHead>Completed At</TableHead>
-                <TableHead>Duration</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {[...runs].sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()).map((run) => (
-                <TableRow key={run.id}>
-                  <TableCell className="font-medium">{run.config?.id ?? "undefined"}</TableCell>
-                  <TableCell>
-                    <span className={`px-2 py-1 rounded-full text-sm ${
-                      run.success ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
-                    }`}>
-                      {run.success ? 'Success' : 'Failed'}
-                    </span>
-                  </TableCell>
-                  <TableCell>{new Date(run.startedAt).toLocaleString()}</TableCell>
-                  <TableCell>{new Date(run.completedAt).toLocaleString()}</TableCell>
-                  <TableCell>
-                    {((new Date(run.completedAt).getTime() - new Date(run.startedAt).getTime()) / 1000).toFixed(2)}s
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
-
-        <div className="flex justify-center gap-2 mt-4">
-          <button
-            onClick={() => setCurrentPage(p => Math.max(0, p - 1))}
-            disabled={currentPage === 0}
-            className="px-4 py-2 text-sm font-medium bg-secondary hover:bg-secondary/80 border border-input rounded-md transition-colors disabled:opacity-50"
-          >
-            Previous
-          </button>
-          <span className="px-4 py-2 text-sm font-medium bg-secondary rounded-md">
-            Page {currentPage + 1}
-          </span>
-          <button
-            onClick={() => setCurrentPage(p => p + 1)}
-            disabled={runs.length < pageSize}
-            className="px-4 py-2 text-sm font-medium bg-secondary hover:bg-secondary/80 border border-input rounded-md transition-colors disabled:opacity-50"
-          >
-            Next
-          </button>
-        </div>
-      </div>
+    <div className="p-8 max-w-none w-full min-h-full">
+      <RunsTable />
     </div>
   );
-};
-
-export default RunsTable;
+}

--- a/packages/web/src/components/ServerMonitor.tsx
+++ b/packages/web/src/components/ServerMonitor.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useState } from 'react';
 import { useToast } from "@/src/hooks/use-toast"
-import { useConfig } from '../app/config-context';
+import { useConfig } from '@/src/app/config-context';
 export function ServerMonitor() {
   const [isServerDown, setIsServerDown] = useState(false);
   const { toast } = useToast()

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Layout, History, Database, Settings, Code, AlertCircle, Shield } from "lucide-react";
+import { Layout, History } from "lucide-react";
 
 const navItems = [
   { icon: Layout, label: 'Configurations', href: '/' },

--- a/packages/web/src/components/apiPlayground.tsx
+++ b/packages/web/src/components/apiPlayground.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/src/components/ui/button";
 import { Card, CardHeader, CardTitle, CardContent } from "@/src/components/ui/card";
 import { Badge } from "@/src/components/ui/badge";
 import { Play, Clock, AlertCircle, Copy } from "lucide-react";
-import { SuperglueClient } from "@superglue/superglue";
+import { SuperglueClient } from "@superglue/client";
 import { useToast } from "@/src/hooks/use-toast";
 import { useConfig } from "@/src/app/config-context";
 

--- a/packages/web/src/components/runsTable.tsx
+++ b/packages/web/src/components/runsTable.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import React from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/src/components/ui/table";
+import { RunResult } from '@superglue/shared';
+import { useConfig } from '../app/config-context';
+import { SuperglueClient } from '@superglue/client';
+
+const RunsTable = ({ id }: { id?: string }) => {
+  const [runs, setRuns] = React.useState<RunResult[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [currentPage, setCurrentPage] = React.useState(0);
+  const pageSize = 50;
+  const config = useConfig();
+
+  React.useEffect(() => {
+    const getRuns = async () => {
+      try { 
+        const superglueClient = new SuperglueClient({
+          endpoint: config.superglueEndpoint,
+          apiKey: config.superglueApiKey
+        })
+        const data = await superglueClient.listRuns(pageSize, currentPage * pageSize, id);
+        setRuns(data.items);
+      } catch (error) {
+        console.error('Error fetching runs:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    getRuns();
+  }, [currentPage]);
+
+  if (loading) {
+    return "";
+  }
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold">API Runs</h1>
+      </div>
+
+      <div className="border rounded-lg">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>API Id</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Started At</TableHead>
+              <TableHead>Completed At</TableHead>
+              <TableHead>Duration</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...runs].sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()).map((run) => (
+              <TableRow key={run.id}>
+                <TableCell className="font-medium">{run.config?.id ?? "undefined"}</TableCell>
+                <TableCell>
+                  <span className={`px-2 py-1 rounded-full text-sm ${
+                    run.success ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+                  }`}>
+                    {run.success ? 'Success' : 'Failed'}
+                  </span>
+                </TableCell>
+                <TableCell>{new Date(run.startedAt).toLocaleString()}</TableCell>
+                <TableCell>{new Date(run.completedAt).toLocaleString()}</TableCell>
+                <TableCell>
+                  {(new Date(run.completedAt).getTime() - new Date(run.startedAt).getTime())}ms
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="flex justify-center gap-2 mt-4">
+        <button
+          onClick={() => setCurrentPage(p => Math.max(0, p - 1))}
+          disabled={currentPage === 0}
+          className="px-4 py-2 text-sm font-medium bg-secondary hover:bg-secondary/80 border border-input rounded-md transition-colors disabled:opacity-50"
+        >
+          Previous
+        </button>
+        <span className="px-4 py-2 text-sm font-medium bg-secondary rounded-md">
+          Page {currentPage + 1}
+        </span>
+        <button
+          onClick={() => setCurrentPage(p => p + 1)}
+          disabled={runs.length < pageSize}
+          className="px-4 py-2 text-sm font-medium bg-secondary hover:bg-secondary/80 border border-input rounded-md transition-colors disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export { RunsTable };

--- a/packages/web/src/hooks/use-toast.ts
+++ b/packages/web/src/hooks/use-toast.ts
@@ -7,7 +7,7 @@ import type {
   ToastActionElement,
   ToastProps,
 } from "@/src/components/ui/toast"
-import { cn } from "../lib/utils"
+import { cn } from "@/src/lib/utils"
 
 const TOAST_LIMIT = 1
 const TOAST_REMOVE_DELAY = 1000000

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
@@ -18,3 +17,13 @@ export function composeUrl(host: string, path: string | undefined) {
   return `${cleanHost}/${cleanPath}`;
 }
 
+export const isJsonEmpty = (inputJson: string) : boolean => {
+  try {
+    if (!inputJson) return true
+    const parsedJson = JSON.parse(inputJson)
+    return Object.keys(parsedJson).length === 0
+  } catch (error) {
+    // If invalid JSON, we consider it empty
+    return true
+  }
+}


### PR DESCRIPTION
Add organization ID support across the application to enable multi-tenant data isolation:

- Update DataStore interface to include orgId parameter in all methods
- Modify Redis and Memory datastores to namespace data by orgId
- Add Redis tests for multi-tenant functionality
- Update GraphQL resolvers to use orgId from context
- Add API key management with Supabase integration
- Update GitHub workflow to include Redis credentials
- Update self-hosting docs with telemetry info

This change enables proper data isolation between different organizations using 
the platform, with data stored and retrieved using organization-specific 
namespaces. The Redis implementation uses key prefixing for isolation, while 
the in-memory store uses separate collections per org.