### PR TITLE
fix empty payload

### DIFF
--- a/packages/core/datastore/filestore.test.ts
+++ b/packages/core/datastore/filestore.test.ts
@@ -98,11 +98,11 @@ describe('FileStore', () => {
     });
 
     it('should handle null payloads when getting extract by request', async () => {
-      const saved = await store.saveExtractConfig(testExtractConfig, null, testExtractConfig, testOrgId);
+      const saved = await store.saveExtractConfig({ urlHost: testExtractConfig.urlHost, instruction: testExtractConfig.instruction }, null, testExtractConfig, testOrgId);
       
       // Test with null payload
       const nullPayloadResult = await store.getExtractConfigFromRequest(
-        testExtractConfig,
+        { urlHost: testExtractConfig.urlHost, instruction: testExtractConfig.instruction },
         null,
         testOrgId
       );
@@ -110,7 +110,7 @@ describe('FileStore', () => {
 
       // Test with undefined payload
       const undefinedPayloadResult = await store.getExtractConfigFromRequest(
-        testExtractConfig,
+        { urlHost: testExtractConfig.urlHost, instruction: testExtractConfig.instruction },
         undefined,
         testOrgId
       );

--- a/packages/core/datastore/filestore.test.ts
+++ b/packages/core/datastore/filestore.test.ts
@@ -96,6 +96,26 @@ describe('FileStore', () => {
       const retrieved = await store.getExtractConfig(testExtractConfig.id, testOrgId);
       expect(retrieved).toBeNull();
     });
+
+    it('should handle null payloads when getting extract by request', async () => {
+      const saved = await store.saveExtractConfig(testExtractConfig, null, testExtractConfig, testOrgId);
+      
+      // Test with null payload
+      const nullPayloadResult = await store.getExtractConfigFromRequest(
+        testExtractConfig,
+        null,
+        testOrgId
+      );
+      expect(nullPayloadResult).toEqual(saved);
+
+      // Test with undefined payload
+      const undefinedPayloadResult = await store.getExtractConfigFromRequest(
+        testExtractConfig,
+        undefined,
+        testOrgId
+      );
+      expect(undefinedPayloadResult).toEqual(saved);
+    });
   });
 
   describe('Transform Config', () => {

--- a/packages/core/datastore/filestore.ts
+++ b/packages/core/datastore/filestore.ts
@@ -1,8 +1,8 @@
 import { ApiConfig, ApiInput, DataStore, ExtractConfig, ExtractInput, RunResult, TransformConfig, TransformInput } from "@superglue/shared";
 import fs from 'fs';
 import path from 'path';
-import toJsonSchema from "to-json-schema";
 import { createHash } from 'crypto';
+import { getSchemaFromData } from "../utils/tools.js";
 
 export class FileStore implements DataStore {
 
@@ -119,7 +119,7 @@ export class FileStore implements DataStore {
 
   async saveApiConfig(request: ApiInput, payload: any, config: ApiConfig, orgId?: string): Promise<ApiConfig> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('api', hash, orgId);
     this.storage.apis.set(key, config);
     await this.persist();
@@ -128,7 +128,7 @@ export class FileStore implements DataStore {
 
   async getApiConfigFromRequest(request: ApiInput, payload: any, orgId?: string): Promise<ApiConfig | null> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('api', hash, orgId);
     const config = this.storage.apis.get(key);
     return config ? { ...config, id: hash } : null;
@@ -167,7 +167,7 @@ export class FileStore implements DataStore {
 
   async saveExtractConfig(request: ExtractInput, payload: any, config: ExtractConfig, orgId: string): Promise<ExtractConfig> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('extract', hash, orgId);
     this.storage.extracts.set(key, config);
     await this.persist();
@@ -176,7 +176,7 @@ export class FileStore implements DataStore {
 
   async getExtractConfigFromRequest(request: ExtractInput, payload: any, orgId?: string): Promise<ExtractConfig | null> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('extract', hash, orgId);
     const config = this.storage.extracts.get(key);
     return config ? { ...config, id: hash } : null;
@@ -215,7 +215,7 @@ export class FileStore implements DataStore {
 
   async saveTransformConfig(request: TransformInput, payload: any, config: TransformConfig, orgId?: string): Promise<TransformConfig> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('transform', hash, orgId);
     this.storage.transforms.set(key, config);
     await this.persist();
@@ -224,7 +224,7 @@ export class FileStore implements DataStore {
 
   async getTransformConfigFromRequest(request: TransformInput, payload: any, orgId?: string): Promise<TransformConfig | null> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('transform', hash, orgId);
     const config = this.storage.transforms.get(key);
     return config ? { ...config, id: hash } : null;

--- a/packages/core/datastore/filestore.ts
+++ b/packages/core/datastore/filestore.ts
@@ -121,6 +121,7 @@ export class FileStore implements DataStore {
     if(!request) return null;
     const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('api', hash, orgId);
+    config.id = hash;
     this.storage.apis.set(key, config);
     await this.persist();
     return { ...config, id: hash };
@@ -169,6 +170,7 @@ export class FileStore implements DataStore {
     if(!request) return null;
     const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('extract', hash, orgId);
+    config.id = hash;
     this.storage.extracts.set(key, config);
     await this.persist();
     return { ...config, id: hash };
@@ -217,6 +219,7 @@ export class FileStore implements DataStore {
     if(!request) return null;
     const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('transform', hash, orgId);
+    config.id = hash;
     this.storage.transforms.set(key, config);
     await this.persist();
     return { ...config, id: hash };

--- a/packages/core/datastore/memory.test.ts
+++ b/packages/core/datastore/memory.test.ts
@@ -74,11 +74,11 @@ describe('MemoryStore', () => {
       expect(retrieved).toBeNull();
     });
     it('should handle null payloads when getting extract by request', async () => {
-      const saved = await store.saveExtractConfig(testExtractConfig, null, testExtractConfig, testOrgId);
+      const saved = await store.saveExtractConfig({ urlHost: testExtractConfig.urlHost, instruction: testExtractConfig.instruction }, null, testExtractConfig, testOrgId);
       
       // Test with null payload
       const nullPayloadResult = await store.getExtractConfigFromRequest(
-        testExtractConfig,
+        { urlHost: testExtractConfig.urlHost, instruction: testExtractConfig.instruction },
         null,
         testOrgId
       );
@@ -86,7 +86,7 @@ describe('MemoryStore', () => {
 
       // Test with undefined payload
       const undefinedPayloadResult = await store.getExtractConfigFromRequest(
-        testExtractConfig,
+        { urlHost: testExtractConfig.urlHost, instruction: testExtractConfig.instruction },
         undefined,
         testOrgId
       );

--- a/packages/core/datastore/memory.test.ts
+++ b/packages/core/datastore/memory.test.ts
@@ -73,6 +73,26 @@ describe('MemoryStore', () => {
       const retrieved = await store.getExtractConfig(testExtractConfig.id, testOrgId);
       expect(retrieved).toBeNull();
     });
+    it('should handle null payloads when getting extract by request', async () => {
+      const saved = await store.saveExtractConfig(testExtractConfig, null, testExtractConfig, testOrgId);
+      
+      // Test with null payload
+      const nullPayloadResult = await store.getExtractConfigFromRequest(
+        testExtractConfig,
+        null,
+        testOrgId
+      );
+      expect(nullPayloadResult).toEqual(saved);
+
+      // Test with undefined payload
+      const undefinedPayloadResult = await store.getExtractConfigFromRequest(
+        testExtractConfig,
+        undefined,
+        testOrgId
+      );
+      expect(undefinedPayloadResult).toEqual(saved);
+    });
+
   });
 
   describe('Transform Config', () => {

--- a/packages/core/datastore/memory.ts
+++ b/packages/core/datastore/memory.ts
@@ -55,6 +55,7 @@ export class MemoryStore implements DataStore {
     if(!request) return null;
     const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('api', hash, orgId);
+    config.id = hash;
     this.storage.apis.set(key, config);
     return { ...config, id: hash };
   }
@@ -100,6 +101,7 @@ export class MemoryStore implements DataStore {
     if(!request) return null;
     const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('extract', hash, orgId);
+    config.id = hash;
     this.storage.extracts.set(key, config);
     return { ...config, id: hash };
   }
@@ -145,6 +147,7 @@ export class MemoryStore implements DataStore {
     if(!request) return null;
     const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('transform', hash, orgId);
+    config.id = hash;
     this.storage.transforms.set(key, config);
     return { ...config, id: hash };
   }

--- a/packages/core/datastore/memory.ts
+++ b/packages/core/datastore/memory.ts
@@ -1,6 +1,6 @@
 import { ApiConfig, ApiInput, DataStore, ExtractConfig, ExtractInput, RunResult, TransformConfig, TransformInput } from "@superglue/shared";
 import { createHash } from 'crypto';
-import toJsonSchema from "to-json-schema";
+import { getSchemaFromData } from "../utils/tools.js";
 
 export class MemoryStore implements DataStore {
   private storage: {
@@ -53,7 +53,7 @@ export class MemoryStore implements DataStore {
 
   async saveApiConfig(request: ApiInput, payload: any, config: ApiConfig, orgId?: string): Promise<ApiConfig> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('api', hash, orgId);
     this.storage.apis.set(key, config);
     return { ...config, id: hash };
@@ -61,7 +61,7 @@ export class MemoryStore implements DataStore {
 
   async getApiConfigFromRequest(request: ApiInput, payload: any, orgId?: string): Promise<ApiConfig | null> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('api', hash, orgId);
     const config = this.storage.apis.get(key);
     return config ? { ...config, id: hash } : null;
@@ -98,7 +98,7 @@ export class MemoryStore implements DataStore {
 
   async saveExtractConfig(request: ExtractInput, payload: any, config: ExtractConfig, orgId: string): Promise<ExtractConfig> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('extract', hash, orgId);
     this.storage.extracts.set(key, config);
     return { ...config, id: hash };
@@ -106,7 +106,7 @@ export class MemoryStore implements DataStore {
 
   async getExtractConfigFromRequest(request: ExtractInput, payload: any, orgId?: string): Promise<ExtractConfig | null> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('extract', hash, orgId);
     const config = this.storage.extracts.get(key);
     return config ? { ...config, id: hash } : null;
@@ -143,7 +143,7 @@ export class MemoryStore implements DataStore {
 
   async saveTransformConfig(request: TransformInput, payload: any, config: TransformConfig, orgId?: string): Promise<TransformConfig> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('transform', hash, orgId);
     this.storage.transforms.set(key, config);
     return { ...config, id: hash };
@@ -151,7 +151,7 @@ export class MemoryStore implements DataStore {
 
   async getTransformConfigFromRequest(request: TransformInput, payload: any, orgId?: string): Promise<TransformConfig | null> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey('transform', hash, orgId);
     const config = this.storage.transforms.get(key);
     return config ? { ...config, id: hash } : null;

--- a/packages/core/datastore/redis.test.ts
+++ b/packages/core/datastore/redis.test.ts
@@ -103,11 +103,11 @@ if (!testConfig.host || !testConfig.port || !testConfig.username || !testConfig.
       });
 
       it('should handle null payloads when getting extract by request', async () => {
-        const saved = await store.saveExtractConfig(testExtractConfig, null, testExtractConfig, testOrgId);
+        const saved = await store.saveExtractConfig({ urlHost: testExtractConfig.urlHost, instruction: testExtractConfig.instruction }, null, testExtractConfig, testOrgId);
         
         // Test with null payload
         const nullPayloadResult = await store.getExtractConfigFromRequest(
-          testExtractConfig,
+          { urlHost: testExtractConfig.urlHost, instruction: testExtractConfig.instruction },
           null,
           testOrgId
         );
@@ -115,7 +115,7 @@ if (!testConfig.host || !testConfig.port || !testConfig.username || !testConfig.
   
         // Test with undefined payload
         const undefinedPayloadResult = await store.getExtractConfigFromRequest(
-          testExtractConfig,
+          { urlHost: testExtractConfig.urlHost, instruction: testExtractConfig.instruction },
           undefined,
           testOrgId
         );

--- a/packages/core/datastore/redis.test.ts
+++ b/packages/core/datastore/redis.test.ts
@@ -101,6 +101,27 @@ if (!testConfig.host || !testConfig.port || !testConfig.username || !testConfig.
         const retrieved = await store.getExtractConfig(testExtractConfig.id, testOrgId);
         expect(retrieved).toBeNull();
       });
+
+      it('should handle null payloads when getting extract by request', async () => {
+        const saved = await store.saveExtractConfig(testExtractConfig, null, testExtractConfig, testOrgId);
+        
+        // Test with null payload
+        const nullPayloadResult = await store.getExtractConfigFromRequest(
+          testExtractConfig,
+          null,
+          testOrgId
+        );
+        expect(nullPayloadResult).toEqual(saved);
+  
+        // Test with undefined payload
+        const undefinedPayloadResult = await store.getExtractConfigFromRequest(
+          testExtractConfig,
+          undefined,
+          testOrgId
+        );
+        expect(undefinedPayloadResult).toEqual(saved);
+      });
+  
     });
 
     describe('Transform Config', () => {

--- a/packages/core/datastore/redis.ts
+++ b/packages/core/datastore/redis.ts
@@ -79,6 +79,7 @@ export class RedisService implements DataStore {
     if(!request) return null;
     const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey(this.API_PREFIX, hash, orgId);
+    config.id = hash;
     await this.redis.set(key, JSON.stringify(config));
     return config;
   }
@@ -146,6 +147,7 @@ export class RedisService implements DataStore {
     if(!request) return null;
     const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey(this.EXTRACT_PREFIX, hash, orgId);
+    config.id = hash;
     await this.redis.set(key, JSON.stringify(config));
     return config;
   }
@@ -189,6 +191,7 @@ export class RedisService implements DataStore {
     if(!request) return null;
     const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey(this.TRANSFORM_PREFIX, hash, orgId);
+    config.id = hash;
     await this.redis.set(key, JSON.stringify(config));
     return config;
   }

--- a/packages/core/datastore/redis.ts
+++ b/packages/core/datastore/redis.ts
@@ -1,7 +1,8 @@
 import { ApiConfig, ApiInput, DataStore, ExtractConfig, ExtractInput, RunResult, TransformConfig, TransformInput } from "@superglue/shared";
 import { createHash } from 'crypto';
 import { createClient, RedisClientType } from 'redis';
-import toJsonSchema from "to-json-schema";
+import { getSchemaFromData } from "../utils/tools.js";
+
 export class RedisService implements DataStore {
   private redis: RedisClientType;
   private readonly RUN_PREFIX = 'run:';
@@ -76,7 +77,7 @@ export class RedisService implements DataStore {
 
   async saveApiConfig(request: ApiInput, payload: any, config: ApiConfig, orgId?: string): Promise<ApiConfig> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey(this.API_PREFIX, hash, orgId);
     await this.redis.set(key, JSON.stringify(config));
     return config;
@@ -84,7 +85,7 @@ export class RedisService implements DataStore {
 
   async getApiConfigFromRequest(request: ApiInput, payload: any, orgId?: string): Promise<ApiConfig | null> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey(this.API_PREFIX, hash, orgId);
     const data = await this.redis.get(key);
     return parseWithId(data, hash);
@@ -92,7 +93,7 @@ export class RedisService implements DataStore {
 
   async getExtractConfigFromRequest(request: ExtractInput, payload: any, orgId?: string): Promise<ExtractConfig | null> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey(this.EXTRACT_PREFIX, hash, orgId);
     const data = await this.redis.get(key);
     return parseWithId(data, hash);
@@ -100,7 +101,7 @@ export class RedisService implements DataStore {
 
   async getTransformConfigFromRequest(request: TransformInput, payload: any, orgId?: string): Promise<TransformConfig | null> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey(this.TRANSFORM_PREFIX, hash, orgId);
     const data = await this.redis.get(key);
     return parseWithId(data, hash);
@@ -143,7 +144,7 @@ export class RedisService implements DataStore {
 
   async saveExtractConfig(request: ExtractInput, payload: any, config: ExtractConfig, orgId?: string): Promise<ExtractConfig> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey(this.EXTRACT_PREFIX, hash, orgId);
     await this.redis.set(key, JSON.stringify(config));
     return config;
@@ -186,7 +187,7 @@ export class RedisService implements DataStore {
 
   async saveTransformConfig(request: TransformInput, payload: any, config: TransformConfig, orgId?: string): Promise<TransformConfig> {
     if(!request) return null;
-    const hash = this.generateHash({request, payloadKeys: toJsonSchema(payload)});
+    const hash = this.generateHash({request, payloadKeys: getSchemaFromData(payload)});
     const key = this.getKey(this.TRANSFORM_PREFIX, hash, orgId);
     await this.redis.set(key, JSON.stringify(config));
     return config;

--- a/packages/core/utils/tools.ts
+++ b/packages/core/utils/tools.ts
@@ -3,6 +3,7 @@ import axios, { AxiosRequestConfig } from "axios";
 import { GraphQLResolveInfo } from "graphql";
 import jsonata from "jsonata";
 import { Validator } from "jsonschema";
+import toJsonSchema from "to-json-schema";
 
 export function isRequested(field: string, info: GraphQLResolveInfo) {
     return info.fieldNodes.some(
@@ -289,4 +290,9 @@ function makeNullable(schema: any): any {
   }
   
   return newSchema;
+}
+
+export function getSchemaFromData(data: any): any {
+  if(!data) return null;
+  return toJsonSchema(data);
 }

--- a/packages/core/utils/transform.ts
+++ b/packages/core/utils/transform.ts
@@ -3,8 +3,8 @@ import { PROMPT_MAPPING } from "./prompts.js";
 import {  applyJsonataWithValidation, sample } from "./tools.js";
 import { ApiInput, DataStore, TransformConfig, TransformInput } from "@superglue/shared";
 import crypto from 'crypto';
-import toJsonSchema from "to-json-schema";
 import { ChatCompletionMessageParam } from "openai/resources/chat/index.mjs";
+import toJsonSchema from "to-json-schema";
 
 export async function prepareTransform(
     datastore: DataStore,


### PR DESCRIPTION
if the payload for extract was empty, the hash generation would fail. I added a test whether there is a payload before generating the jsonSchema from it which resolves the issue.