### PR TITLE
Fixed bug in instruction suggestions

### DIFF
--- a/packages/core/utils/instructions.test.ts
+++ b/packages/core/utils/instructions.test.ts
@@ -138,13 +138,62 @@ describe('sanitizeInstructionSuggestions', () => {
     ]);
   });
 
-  it('removes headers and markdown from array', () => {
+  it('removes headers and markdown from array (classic)', () => {
     const input = [
       '**Individual Suggestions:**',
       '- Get all users',
       '- Fetch all orders',
       '**Integration Suggestions:**',
       '- Sync data'
+    ];
+    expect(sanitizeInstructionSuggestions(input)).toEqual([
+      'Get all users',
+      'Fetch all orders',
+      'Sync data'
+    ]);
+  });
+
+  it('removes headers and markdown from array (various cases)', () => {
+    const input = [
+      '# Example Output',
+      '## Integration Suggestions',
+      '---',
+      '***',
+      'Output:',
+      'Example:',
+      'Individual Suggestions',
+      'Integration Suggestions',
+      'Get all users',
+      'Fetch all orders',
+      'Sync data',
+      '***Integration Suggestions***',
+      '   ##   Example Output   ',
+      '   * Individual Suggestions *   ',
+      '   # Output:   ',
+      '   ----   ',
+      '   ***   ',
+      '   ',
+      '',
+      '   #   ',
+      '   *   ',
+      '   -   ',
+      '   _   ',
+      '   >   ',
+      '   > Output:',
+      '   > Example:',
+      '   > Integration Suggestions',
+      '   > Individual Suggestions',
+      '   > # Example Output',
+      '   > ## Integration Suggestions',
+      '   > ---',
+      '   > ***',
+      '   > Output:',
+      '   > Example:',
+      '   > Individual Suggestions',
+      '   > Integration Suggestions',
+      '   > Get all users',
+      '   > Fetch all orders',
+      '   > Sync data',
     ];
     expect(sanitizeInstructionSuggestions(input)).toEqual([
       'Get all users',
@@ -177,4 +226,9 @@ describe('sanitizeInstructionSuggestions', () => {
     }
     expect(result).toEqual([]);
   });
-}); 
+
+  it('handles non-string, non-array input', () => {
+    expect(sanitizeInstructionSuggestions(42)).toEqual([]);
+    expect(sanitizeInstructionSuggestions({ foo: 'bar' })).toEqual([]);
+  });
+}) 

--- a/packages/web/src/components/workflow/WorkflowCreateStepper.tsx
+++ b/packages/web/src/components/workflow/WorkflowCreateStepper.tsx
@@ -900,8 +900,8 @@ export function WorkflowCreateStepper({ onComplete }: WorkflowCreateStepperProps
                     className={cn("min-h-80", validationErrors.instruction && inputErrorStyles)}
                   />
                   {suggestions.length > 0 && !instruction && (
-                    <div className="absolute bottom-0  p-3 pointer-events-none">
-                      <div className="flex flex-wrap gap-2">
+                    <div className="absolute bottom-0 p-3 pointer-events-none w-full">
+                      <div className="flex gap-2 overflow-x-auto whitespace-nowrap w-full">
                         {suggestions.map((suggestion, index) => (
                           <Button
                             key={index}


### PR DESCRIPTION
**🧹 LLM Output Sanitization**
Added a sanitizeInstructionSuggestions utility to clean up LLM output:
Removes markdown, headers, separator lines, and deduplicates suggestions.
Handles weird/malformed LLM output gracefully.
Updated the LLM prompt to require a strict JSON array of strings (no markdown, bullets, or explanations).
**🧪 Testing**
Expanded unit tests for the sanitizer to cover edge cases (headers, markdown, malformed input, deduplication, etc).
Ensured sanitizer is always used before returning suggestions from the backend.
**💅 UI Enhancements**
Improved the workflow suggestion display in WorkflowCreateStepper:
Better horizontal scrolling and layout for suggestion buttons.

**Result:**
Instruction suggestions are now much more robust, clean, and user-friendly, and are no longer being displayed incorrectly in the UI. All changes are covered by comprehensive tests.


**Note:** 
We can discuss whether having an LLM output sanitization logic is really necessary. With the new prompt, the outputs were extremely consistent in manual testing and never required sanitization. It's also very difficult to handle all possible edge cases in the LLM output, but I have kept the sanitization logic as an additional safety layer and corresponding tests in the PR for now. We can remove it if we feel it's unnecessary / doesn't add much value.