### PR TITLE
modified prompts to cover edge cases

### DIFF
--- a/packages/core/llm/prompts.ts
+++ b/packages/core/llm/prompts.ts
@@ -298,6 +298,7 @@ Output the plan as a JSON object adhering to the specified schema.
 - Choose the appropriate system for each step based on the provided documentation
 - Assign descriptive stepIds in camelCase that indicate the purpose of the step
 - Make absolutely sure that each step can be achieved with a single API call (or a loop of the same call)
+- Aggregation, grouping, sorting, filtering is covered by a separate final transformation and does not need to be added as a dedicated step. However, if the API supports e.g. filtering when retrieving, this should be part of the retrieval step, just do not add an extra one.
 </STEP_CREATION>
 
 <EXECUTION_MODES>

--- a/packages/core/utils/api.ts
+++ b/packages/core/utils/api.ts
@@ -330,7 +330,8 @@ If the instruction contains a filter and the response contains data not matching
 If the reponse is valid but hard to comprehend, return { success: true, refactorNeeded: true, shortReason: "The response is valid but hard to comprehend. Please refactor the instruction to make it easier to understand." }.
 E.g. if the response is something like { "data": { "products": [{"id": 1, "name": "Product 1"}, {"id": 2, "name": "Product 2"}] } }, no refactoring is needed.
 If the response reads something like [ "12/2", "22.2", "frejgeiorjgrdelo"] that makes it very hard to parse the required information of the instruction, refactoring is needed. 
-Refactoring is NOT needed if the response contains extra fields.
+If the response needs to be grouped or sorted or aggregated, this will be handled in a later step, so the appropriate response for you is to return { success: true, refactorNeeded: false, shortReason: "" }.
+Refactoring is NOT needed if the response contains extra fields or needs to be grouped.
 
 Instruction: ${instruction}`
     },


### PR DESCRIPTION
Planning: Aggregation, grouping, sorting, filtering is covered by a separate final transformation and does not need to be added as a dedicated step. However, if the API supports e.g. filtering when retrieving, this should be part of the retrieval step, just do not add an extra one.
Evaluation: If the response needs to be grouped or sorted or aggregated, this will be handled in a later step, so the appropriate response for you is to return { success: true, refactorNeeded: false, shortReason: "" }.