### PR TITLE
Datastore Improvements

### DIFF
--- a/packages/core/datastore/filestore.test.ts
+++ b/packages/core/datastore/filestore.test.ts
@@ -334,6 +334,40 @@ describe('FileStore', () => {
       expect(retrieved).toBeNull();
     });
 
+    it('should get many integrations by ids, skipping missing ones', async () => {
+      const int2 = { ...testIntegration, id: 'test-int-id-2', name: 'Integration 2' };
+      await store.upsertIntegration(testIntegration.id, testIntegration, testOrgId);
+      await store.upsertIntegration(int2.id, int2, testOrgId);
+      const result = await store.getManyIntegrations([
+        testIntegration.id,
+        int2.id,
+        'missing-id'
+      ], testOrgId);
+      expect(result).toHaveLength(2);
+      expect(result.map(i => i.id).sort()).toEqual([testIntegration.id, int2.id].sort());
+    });
+  });
+
+  describe('Workflow', () => {
+    const testWorkflow = {
+      id: 'test-workflow-id',
+      steps: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('should get many workflows by ids, skipping missing ones', async () => {
+      const wf2 = { ...testWorkflow, id: 'test-workflow-id-2' };
+      await store.upsertWorkflow(testWorkflow.id, testWorkflow, testOrgId);
+      await store.upsertWorkflow(wf2.id, wf2, testOrgId);
+      const result = await store.getManyWorkflows([
+        testWorkflow.id,
+        wf2.id,
+        'missing-id'
+      ], testOrgId);
+      expect(result).toHaveLength(2);
+      expect(result.map(w => w.id).sort()).toEqual([testWorkflow.id, wf2.id].sort());
+    });
   });
 
   describe('Clear All', () => {

--- a/packages/core/datastore/filestore.ts
+++ b/packages/core/datastore/filestore.ts
@@ -559,6 +559,17 @@ export class FileStore implements DataStore {
     return { items, total };
   }
 
+  async getManyWorkflows(ids: string[], orgId?: string): Promise<Workflow[]> {
+    await this.ensureInitialized();
+    return ids
+      .map(id => {
+        const key = this.getKey('workflow', id, orgId);
+        const workflow = this.storage.workflows.get(key);
+        return workflow ? { ...workflow, id } : null;
+      })
+      .filter((w): w is Workflow => w !== null);
+  }
+
   async upsertWorkflow(id: string, workflow: Workflow, orgId?: string): Promise<Workflow> {
     await this.ensureInitialized();
     if (!id || !workflow) return null;
@@ -592,6 +603,17 @@ export class FileStore implements DataStore {
     const items = orgItems.slice(offset, offset + limit);
     const total = orgItems.length;
     return { items, total };
+  }
+
+  async getManyIntegrations(ids: string[], orgId?: string): Promise<Integration[]> {
+    await this.ensureInitialized();
+    return ids
+      .map(id => {
+        const key = this.getKey('integration', id, orgId);
+        const integration = this.storage.integrations.get(key);
+        return integration ? { ...integration, id } : null;
+      })
+      .filter((i): i is Integration => i !== null);
   }
 
   async upsertIntegration(id: string, integration: Integration, orgId?: string): Promise<Integration> {

--- a/packages/core/datastore/memory.test.ts
+++ b/packages/core/datastore/memory.test.ts
@@ -290,6 +290,41 @@ describe('MemoryStore', () => {
       const retrieved = await store.getIntegration('does-not-exist', testOrgId);
       expect(retrieved).toBeNull();
     });
+
+    it('should get many integrations by ids, skipping missing ones', async () => {
+      const int2 = { ...testIntegration, id: 'test-int-id-2', name: 'Integration 2' };
+      await store.upsertIntegration(testIntegration.id, testIntegration, testOrgId);
+      await store.upsertIntegration(int2.id, int2, testOrgId);
+      const result = await store.getManyIntegrations([
+        testIntegration.id,
+        int2.id,
+        'missing-id'
+      ], testOrgId);
+      expect(result).toHaveLength(2);
+      expect(result.map(i => i.id).sort()).toEqual([testIntegration.id, int2.id].sort());
+    });
+  });
+
+  describe('Workflow', () => {
+    const testWorkflow = {
+      id: 'test-workflow-id',
+      steps: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('should get many workflows by ids, skipping missing ones', async () => {
+      const wf2 = { ...testWorkflow, id: 'test-workflow-id-2' };
+      await store.upsertWorkflow(testWorkflow.id, testWorkflow, testOrgId);
+      await store.upsertWorkflow(wf2.id, wf2, testOrgId);
+      const result = await store.getManyWorkflows([
+        testWorkflow.id,
+        wf2.id,
+        'missing-id'
+      ], testOrgId);
+      expect(result).toHaveLength(2);
+      expect(result.map(w => w.id).sort()).toEqual([testWorkflow.id, wf2.id].sort());
+    });
   });
 
   describe('Clear All', () => {

--- a/packages/core/datastore/memory.ts
+++ b/packages/core/datastore/memory.ts
@@ -256,6 +256,16 @@ export class MemoryStore implements DataStore {
     return { items, total };
   }
 
+  async getManyWorkflows(ids: string[], orgId?: string): Promise<Workflow[]> {
+    return ids
+      .map(id => {
+        const key = this.getKey('workflow', id, orgId);
+        const workflow = this.storage.workflows.get(key);
+        return workflow ? { ...workflow, id } : null;
+      })
+      .filter((w): w is Workflow => w !== null);
+  }
+
   async upsertWorkflow(id: string, workflow: Workflow, orgId?: string): Promise<Workflow> {
     if (!id || !workflow) return null;
     const key = this.getKey('workflow', id, orgId);
@@ -283,6 +293,16 @@ export class MemoryStore implements DataStore {
     const items = orgItems.slice(offset, offset + limit);
     const total = orgItems.length;
     return { items, total };
+  }
+
+  async getManyIntegrations(ids: string[], orgId?: string): Promise<Integration[]> {
+    return ids
+      .map(id => {
+        const key = this.getKey('integration', id, orgId);
+        const integration = this.storage.integrations.get(key);
+        return integration ? { ...integration, id } : null;
+      })
+      .filter((i): i is Integration => i !== null);
   }
 
   async upsertIntegration(id: string, integration: Integration, orgId?: string): Promise<Integration> {

--- a/packages/core/datastore/redis.test.ts
+++ b/packages/core/datastore/redis.test.ts
@@ -299,6 +299,41 @@ if (!testConfig.host || !testConfig.port || !testConfig.username || !testConfig.
         const retrieved = await store.getIntegration('does-not-exist', testOrgId);
         expect(retrieved).toBeNull();
       });
+
+      it('should get many integrations by ids, skipping missing ones', async () => {
+        const int2 = { ...testIntegration, id: 'test-int-id-2', name: 'Integration 2' };
+        await store.upsertIntegration(testIntegration.id, testIntegration, testOrgId);
+        await store.upsertIntegration(int2.id, int2, testOrgId);
+        const result = await store.getManyIntegrations([
+          testIntegration.id,
+          int2.id,
+          'missing-id'
+        ], testOrgId);
+        expect(result).toHaveLength(2);
+        expect(result.map(i => i.id).sort()).toEqual([testIntegration.id, int2.id].sort());
+      });
+    });
+
+    describe('Workflow', () => {
+      const testWorkflow = {
+        id: 'test-workflow-id',
+        steps: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      it('should get many workflows by ids, skipping missing ones', async () => {
+        const wf2 = { ...testWorkflow, id: 'test-workflow-id-2' };
+        await store.upsertWorkflow(testWorkflow.id, testWorkflow, testOrgId);
+        await store.upsertWorkflow(wf2.id, wf2, testOrgId);
+        const result = await store.getManyWorkflows([
+          testWorkflow.id,
+          wf2.id,
+          'missing-id'
+        ], testOrgId);
+        expect(result).toHaveLength(2);
+        expect(result.map(w => w.id).sort()).toEqual([testWorkflow.id, wf2.id].sort());
+      });
     });
 
     describe('Health Check', () => {

--- a/packages/core/datastore/redis.ts
+++ b/packages/core/datastore/redis.ts
@@ -66,15 +66,14 @@ export class RedisService implements DataStore {
     const pattern = this.getPattern(this.API_PREFIX, orgId);
     const keys = await this.redis.keys(pattern);
     const slicedKeys = keys.slice(offset, offset + limit);
-
-    const configs = await Promise.all(
-      slicedKeys.map(async (key) => {
-        const data = await this.redis.get(key);
-        const id = key.split(':').pop()!.replace(this.API_PREFIX, '');
-        return parseWithId(data, id);
-      })
-    );
-    return { items: configs.filter((config): config is ApiConfig => config !== null), total: keys.length };
+    const dataArray = slicedKeys.length > 0 ? await this.redis.mGet(slicedKeys) : [];
+    const configs = slicedKeys.map((key, index) => {
+      const data = dataArray[index];
+      if (!data) return null;
+      const id = key.split(':').pop()!.replace(this.API_PREFIX, '');
+      return parseWithId(data, id);
+    });
+    return { items: configs.filter((c): c is ApiConfig => c !== null), total: keys.length };
   }
 
   async upsertApiConfig(id: string, config: ApiConfig, orgId: string): Promise<ApiConfig> {
@@ -97,19 +96,18 @@ export class RedisService implements DataStore {
     return parseWithId(data, id);
   }
 
-  async listExtractConfigs(limit = 10, offset = 0, orgId: string): Promise<{ items: ExtractConfig[], total: number }> {
+  async listExtractConfigs(limit = 10, offset = 0, orgId?: string): Promise<{ items: ExtractConfig[], total: number }> {
     const pattern = this.getPattern(this.EXTRACT_PREFIX, orgId);
     const keys = await this.redis.keys(pattern);
     const slicedKeys = keys.slice(offset, offset + limit);
-
-    const configs = await Promise.all(
-      slicedKeys.map(async (key) => {
-        const data = await this.redis.get(key);
-        const id = key.split(':').pop()!.replace(this.EXTRACT_PREFIX, '');
-        return parseWithId(data, id);
-      })
-    );
-    return { items: configs.filter((config): config is ExtractConfig => config !== null), total: keys.length };
+    const dataArray = slicedKeys.length > 0 ? await this.redis.mGet(slicedKeys) : [];
+    const configs = slicedKeys.map((key, index) => {
+      const data = dataArray[index];
+      if (!data) return null;
+      const id = key.split(':').pop()!.replace(this.EXTRACT_PREFIX, '');
+      return parseWithId(data, id);
+    });
+    return { items: configs.filter((c): c is ExtractConfig => c !== null), total: keys.length };
   }
 
   async upsertExtractConfig(id: string, config: ExtractConfig, orgId?: string): Promise<ExtractConfig> {
@@ -136,15 +134,14 @@ export class RedisService implements DataStore {
     const pattern = this.getPattern(this.TRANSFORM_PREFIX, orgId);
     const keys = await this.redis.keys(pattern);
     const slicedKeys = keys.slice(offset, offset + limit);
-
-    const configs = await Promise.all(
-      slicedKeys.map(async (key) => {
-        const data = await this.redis.get(key);
-        const id = key.split(':').pop()!.replace(this.TRANSFORM_PREFIX, '');
-        return parseWithId(data, id);
-      })
-    );
-    return { items: configs.filter((config): config is TransformConfig => config !== null), total: keys.length };
+    const dataArray = slicedKeys.length > 0 ? await this.redis.mGet(slicedKeys) : [];
+    const configs = slicedKeys.map((key, index) => {
+      const data = dataArray[index];
+      if (!data) return null;
+      const id = key.split(':').pop()!.replace(this.TRANSFORM_PREFIX, '');
+      return parseWithId(data, id);
+    });
+    return { items: configs.filter((c): c is TransformConfig => c !== null), total: keys.length };
   }
 
   async upsertTransformConfig(id: string, config: TransformConfig, orgId?: string): Promise<TransformConfig> {
@@ -314,15 +311,13 @@ export class RedisService implements DataStore {
       const pattern = this.getPattern(this.WORKFLOW_PREFIX, orgId);
       const keys = await this.redis.keys(pattern);
       const slicedKeys = keys.slice(offset, offset + limit);
-
-      const workflows = await Promise.all(
-        slicedKeys.map(async (key) => {
-          const data = await this.redis.get(key);
-          const id = key.split(':').pop()?.replace(this.WORKFLOW_PREFIX, '');
-          return parseWithId(data, id);
-        })
-      );
-
+      const dataArray = slicedKeys.length > 0 ? await this.redis.mGet(slicedKeys) : [];
+      const workflows = slicedKeys.map((key, index) => {
+        const data = dataArray[index];
+        if (!data) return null;
+        const id = key.split(':').pop()?.replace(this.WORKFLOW_PREFIX, '');
+        return parseWithId(data, id);
+      });
       return {
         items: workflows.filter((workflow): workflow is Workflow => workflow !== null),
         total: keys.length
@@ -331,6 +326,15 @@ export class RedisService implements DataStore {
       console.error('Error listing workflows:', error);
       return { items: [], total: 0 };
     }
+  }
+
+  async getManyWorkflows(ids: string[], orgId?: string): Promise<Workflow[]> {
+    if (!ids.length) return [];
+    const keys = ids.map(id => this.getKey(this.WORKFLOW_PREFIX, id, orgId));
+    const dataArray = await this.redis.mGet(keys);
+    return dataArray
+      .map((data, i) => data ? parseWithId(data, ids[i]) : null)
+      .filter((w): w is Workflow => w !== null);
   }
 
   async upsertWorkflow(id: string, workflow: Workflow, orgId?: string): Promise<Workflow> {
@@ -371,15 +375,23 @@ export class RedisService implements DataStore {
     const pattern = this.getPattern(this.INTEGRATION_PREFIX, orgId);
     const keys = await this.redis.keys(pattern);
     const slicedKeys = keys.slice(offset, offset + limit);
-
-    const integrations = await Promise.all(
-      slicedKeys.map(async (key) => {
-        const data = await this.redis.get(key);
-        const id = key.split(':').pop()!.replace(this.INTEGRATION_PREFIX, '');
-        return parseWithId(data, id);
-      })
-    );
+    const dataArray = slicedKeys.length > 0 ? await this.redis.mGet(slicedKeys) : [];
+    const integrations = slicedKeys.map((key, index) => {
+      const data = dataArray[index];
+      if (!data) return null;
+      const id = key.split(':').pop()!.replace(this.INTEGRATION_PREFIX, '');
+      return parseWithId(data, id);
+    });
     return { items: integrations.filter((i): i is Integration => i !== null), total: keys.length };
+  }
+
+  async getManyIntegrations(ids: string[], orgId?: string): Promise<Integration[]> {
+    if (!ids.length) return [];
+    const keys = ids.map(id => this.getKey(this.INTEGRATION_PREFIX, id, orgId));
+    const dataArray = await this.redis.mGet(keys);
+    return dataArray
+      .map((data, i) => data ? parseWithId(data, ids[i]) : null)
+      .filter((i): i is Integration => i !== null);
   }
 
   async upsertIntegration(id: string, integration: Integration, orgId?: string): Promise<Integration> {

--- a/packages/core/datastore/types.ts
+++ b/packages/core/datastore/types.ts
@@ -30,6 +30,7 @@ export interface DataStore {
   listWorkflows(limit?: number, offset?: number, orgId?: string): Promise<{ items: Workflow[], total: number }>;
   upsertWorkflow(id: string, workflow: Workflow, orgId?: string): Promise<Workflow>;
   deleteWorkflow(id: string, orgId?: string): Promise<boolean>;
+  getManyWorkflows(ids: string[], orgId?: string): Promise<Workflow[]>;
 
   // Tenant Information Methods
   getTenantInfo(): Promise<{ email: string | null, emailEntrySkipped: boolean }>;
@@ -40,4 +41,5 @@ export interface DataStore {
   listIntegrations(limit?: number, offset?: number, orgId?: string): Promise<{ items: Integration[], total: number }>;
   upsertIntegration(id: string, integration: Integration, orgId?: string): Promise<Integration>;
   deleteIntegration(id: string, orgId?: string): Promise<boolean>;
+  getManyIntegrations(ids: string[], orgId?: string): Promise<Integration[]>;
 }

--- a/packages/shared/utils.ts
+++ b/packages/shared/utils.ts
@@ -46,6 +46,7 @@ export async function generateUniqueId({
 // Generic interface for anything that can fetch integrations
 interface IntegrationGetter {
     getIntegration(id: string): Promise<Integration | null>;
+    getManyIntegrations?(ids: string[]): Promise<Integration[]>;
 }
 
 // Generic integration polling utility that works with any integration getter
@@ -58,34 +59,26 @@ export async function waitForIntegrationProcessing(
     const start = Date.now();
 
     while (Date.now() - start < timeoutMs) {
-        // Fetch all integrations
-        const settled = await Promise.allSettled(
-            integrationIds.map(async (id) => {
-                try {
-                    return await integrationGetter.getIntegration(id);
-                } catch (error) {
-                    console.warn(`Failed to fetch integration ${id}:`, error);
-                    return null;
-                }
-            })
-        );
-
-        const integrations = settled.map(result =>
-            result.status === 'fulfilled' ? result.value : null
-        ).filter(Boolean) as Integration[];
-
-        // Check if any integration is still pending documentation
-        const hasPendingDocs = integrations.some(integration => integration.documentationPending === true);
-
-        if (!hasPendingDocs) {
-            return integrations;
+        let integrations: Integration[];
+        if (integrationGetter.getManyIntegrations) {
+            integrations = await integrationGetter.getManyIntegrations(integrationIds);
+        } else {
+            const settled = await Promise.allSettled(
+                integrationIds.map(async (id) => {
+                    try {
+                        return await integrationGetter.getIntegration(id);
+                    } catch {
+                        return null;
+                    }
+                })
+            );
+            integrations = settled.map(r => r.status === 'fulfilled' ? r.value : null).filter(Boolean) as Integration[];
         }
-
-        // Wait before checking again
+        const hasPendingDocs = integrations.some(i => i.documentationPending === true);
+        if (!hasPendingDocs) return integrations;
         await new Promise(resolve => setTimeout(resolve, 4000));
     }
 
-    // Timeout occurred - just use the integration IDs since we know they exist
     throw new Error(
         `Workflow build timed out after ${timeoutMs / 1000} seconds waiting for documentation processing to complete for: ${integrationIds.join(', ')}. Please try again in a few minutes.`
     );


### PR DESCRIPTION
## Summary of Improvements

### 1. Added `getMany` Patterns to Datastore

- Introduced `getManyIntegrations` and `getManyWorkflows` methods to all backend datastores (Redis, Memory, FileStore).
- **Reasoning:** These batch-fetch methods allow efficient retrieval of multiple objects by ID in a single call, eliminating the need for repeated single-object fetches. This is especially important for Redis, where each call is a network roundtrip.
- The `getMany` pattern is currently **only implemented in the backend**. The frontend and client SDKs still use single-object fetches, as batch APIs are not exposed there yet. TBD if we need them there at some point.

### 2. Eliminated N+1 Query Patterns

- Refactored all `listX` operations in the Redis datastore to use `mget` for batch retrieval, reducing N+1 queries to just two queries (keys + mget) per list operation.
- Updated backend code to use `getManyIntegrations` wherever a set of integrations is needed, replacing inefficient `Promise.all` patterns of individual `getIntegration` calls.
- This results in significant performance improvements, especially for large organizations or high-latency environments.

### 3. Future-Proofing with `getManyWorkflows`

- Added `getManyWorkflows` to the backend datastores, even though it is **not used yet**.
- This anticipates future use cases where batch workflow retrieval will be needed (e.g., for analytics, reporting, or bulk operations). 

---

**Note:**  
- The `getMany` functions are backend-only for now. If/when batch APIs are needed in the frontend or client SDK, similar patterns can be added.
- All changes are backward compatible and do not affect existing single-object fetches or list operations for small datasets.

---