### PR TITLE
add retries to default setting and set call retries to 10

### DIFF
--- a/packages/core/default.ts
+++ b/packages/core/default.ts
@@ -5,5 +5,7 @@ export const config = {
         // this is the public key for the posthog project. This can be public, this is not a secret.
         apiKey: 'phc_89mcVkZ9osPaFQwTp3oFA2595ne95OSNk47qnhqCCbE',
         host: 'https://d22ze2hfwgrlye.cloudfront.net',
-    }
+    },
+    MAX_CALL_RETRIES: 10,
+    MAX_TRANSFORMATION_RETRIES: 10
 }

--- a/packages/core/graphql/resolvers/call.ts
+++ b/packages/core/graphql/resolvers/call.ts
@@ -2,6 +2,7 @@ import { ApiConfig, ApiInputRequest, CacheMode, Integration, RequestOptions, Sel
 import type { Context, Metadata } from "@superglue/shared";
 import { GraphQLResolveInfo } from "graphql";
 import OpenAI from "openai";
+import { config } from "../../default.js";
 import { PROMPT_MAPPING } from "../../llm/prompts.js";
 import { callEndpoint, evaluateResponse, generateApiConfig } from "../../utils/api.js";
 import { Documentation } from "../../utils/documentation.js";
@@ -91,7 +92,7 @@ export async function executeApiCall(
       }
     }
     retryCount++;
-  } while (retryCount < (options?.retries !== undefined ? options.retries : 8));
+  } while (retryCount < (options?.retries !== undefined ? options.retries : config.MAX_CALL_RETRIES));
   if (!success) {
     telemetryClient?.captureException(new Error(`API call failed after ${retryCount} retries. Last error: ${lastError}`), metadata.orgId, {
       endpoint: endpoint,

--- a/packages/core/graphql/tests/call.test.ts
+++ b/packages/core/graphql/tests/call.test.ts
@@ -2,6 +2,7 @@ import { ApiInputRequest, CacheMode, RequestOptions } from "@superglue/client";
 import { Context, Metadata } from "@superglue/shared";
 import { GraphQLResolveInfo } from "graphql";
 import { afterEach, beforeEach, describe, expect, it, vi, type Mocked } from 'vitest';
+import { config } from "../../default.js";
 import * as api from "../../utils/api.js";
 import { Documentation } from "../../utils/documentation.js";
 import * as logs from "../../utils/logs.js";
@@ -157,9 +158,9 @@ describe('Call Resolver', () => {
       )).rejects.toThrow(/API call failed after \d+ retries.*Last error: Eval failed/);
 
       // callEndpoint is called once for the initial attempt, then 7 more times for retries where evaluateResponse fails.
-      expect(mockedApi.callEndpoint).toHaveBeenCalledTimes(8);
+      expect(mockedApi.callEndpoint). toHaveBeenCalledTimes(config.MAX_CALL_RETRIES);
       // evaluateResponse is called for each of the 7 retries after the first callEndpoint failure.
-      expect(mockedApi.evaluateResponse).toHaveBeenCalledTimes(7);
+      expect(mockedApi.evaluateResponse).toHaveBeenCalledTimes(config.MAX_CALL_RETRIES - 1);
       expect(mockedTelemetry.telemetryClient?.captureException).toHaveBeenCalled();
     });
 
@@ -227,7 +228,7 @@ describe('Call Resolver', () => {
         mockContext
       )).rejects.toThrow(/API call failed after \d+ retries/);
 
-      expect(mockedApi.callEndpoint).toHaveBeenCalledTimes(8);
+      expect(mockedApi.callEndpoint).toHaveBeenCalledTimes(config.MAX_CALL_RETRIES);
     });
   });
 

--- a/packages/core/utils/transform.ts
+++ b/packages/core/utils/transform.ts
@@ -2,6 +2,7 @@ import { RequestOptions, SelfHealingMode, TransformConfig, TransformInputRequest
 import type { DataStore, Metadata } from "@superglue/shared";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import prettier from "prettier";
+import { config } from "../default.js";
 import { LanguageModel } from "../llm/llm.js";
 import { PROMPT_JS_TRANSFORM, PROMPT_MAPPING } from "../llm/prompts.js";
 import { logMessage } from "./logs.js";
@@ -205,7 +206,7 @@ ${JSON.stringify(sample(payload, 2), null, 2).slice(0, 50000)}
     logMessage('info', `Mapping generated successfully with ${response.confidence}% confidence`, metadata);
     return response;
   } catch (error) {
-    if (retry < 10) {
+    if (retry < config.MAX_TRANSFORMATION_RETRIES) {
       const errorMessage = String(error.message);
       logMessage('warn', "Error generating JS mapping: " + errorMessage.slice(0, 1000), metadata);
       messages?.push({ role: "user", content: errorMessage });


### PR DESCRIPTION
## 📦 Pull Request Summary

This PR adds retries to default setting and sets call retries to 10

## 🎯 Motivation / Context

We felt that 10 retries by default would be reasonable since they are pretty fast with the default model.
---

## ✅ Contributor Checklist

- [x] Documentation is up-to-date
- [-] MCP tool descriptions and instructions are up-to-date
- [-] Client SDK updated (if applicable)
- [-] Integration test suite has been run and passes (may not be necessary)
- [x] Unit tests added or updated (if applicable)
- [x] Changes are covered by tests

---

## ⚠️ Compatibility Notes

- [x] ✅ Fully backward compatible
- [ ] ⚠️ Minor behavioral change (non-breaking)
- [ ] ❌ Breaking change — migration steps documented below

---