### PR TITLE
docs: fix incorrect docs URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <h3 align="center"> Now live: let agents build deterministic workflows across apps, databases and APIs using the superglue MCP<br>
 Let's glue.<br>
 
-[Read the docs](https://docs.superglue.cloud/mcp) 🍯🍯🍯</h3>
+[Read the docs](https://docs.superglue.cloud) 🍯🍯🍯</h3>
 
 
 ## what is superglue?


### PR DESCRIPTION
## 📦 Pull Request Summary

Fix incorrect docs URL in README.md file in the root directory.

---

## 🎯 Motivation / Context

We want the repository viewer to find the correct docs without being redirected to the MCP server.

---

## ✅ Contributor Checklist

- [x] Documentation is up-to-date
- [ ] MCP tool descriptions and instructions are up-to-date
- [ ] Client SDK updated (if applicable)
- [ ] Integration test suite has been run and passes (may not be necessary)
- [ ] Unit tests added or updated (if applicable)
- [ ] Changes are covered by tests

---

## ⚠️ Compatibility Notes

- [x] ✅ Fully backward compatible
- [ ] ⚠️ Minor behavioral change (non-breaking)
- [ ] ❌ Breaking change — migration steps documented below

<details>
<summary>🔁 Migration Notes (if applicable)</summary>

<!-- Describe any required actions for downstream consumers -->

</details>

---

## 📝 Additional Notes

<!-- Any extra context, links, known issues, or follow-up tasks -->

