### PR TITLE
Increase sample size of transform code gen

### DIFF
--- a/packages/core/utils/transform.ts
+++ b/packages/core/utils/transform.ts
@@ -104,7 +104,7 @@ export async function generateTransformCode(
 ${instruction ? `<user_instruction>${instruction}</user_instruction>` : ''}
 ${schema ? `<target_schema>${JSON.stringify(schema, null, 2)}</target_schema>` : ''}
 <source_data_structure>${getSchemaFromData(payload)}</source_data_structure>
-<source_data_sample>${JSON.stringify(sample(payload, 2), null, 2).slice(0, 50000)}</source_data_sample>
+<source_data_sample>${JSON.stringify(sample(payload, 20), null, 2).slice(0, 50000)}</source_data_sample>
 `;
       messages = [
         { role: "system", content: PROMPT_JS_TRANSFORM },


### PR DESCRIPTION
## 📦 Pull Request Summary

Increase sample size of transform code gen to 20

### ✨ What’s Changed

Increase sample size of transform code gen to 20 from 2. 
---

## 🎯 Motivation / Context

In cases where the structure is an array of values we have very little visibility in the structure of the array.
E.g. 
[{name:xx, value:1}, {name:yy, value:2}, ....] would sample out all but 2 values. this tanks performance even when the input is not that large.
---

## ✅ Contributor Checklist

- [x] Documentation is up-to-date
- [x] MCP tool descriptions and instructions are up-to-date
- [x] Client SDK updated (if applicable)
- [x] Unit tests added or updated (if applicable)

---

## ⚠️ Compatibility Notes

- [x] ✅ Fully backward compatible
- [ ] ⚠️ Minor behavioral change (non-breaking)
- [ ] ❌ Breaking change — migration steps documented below
