### PR TITLE
Fixed sitemap processing bug and tweaked worker pool impl. to work in local dev

### DIFF
--- a/packages/core/default.ts
+++ b/packages/core/default.ts
@@ -17,6 +17,8 @@ export const server_defaults = {
         MAX_FETCHED_LINKS: 20,
         MAX_PAGES_TO_FETCH_IN_PARALLEL: 4,
         MAX_SITEMAP_DEPTH: 3,
+        MAX_SITEMAPS_PER_DEPTH: 10, // Limit per depth level to prevent explosion at any single level
+        MAX_TOTAL_SITEMAPS: 20, // Global limit across all depths to bound total processing
         MAX_CONCURRENT_OPENAPI_FETCHES: 25,
         MAX_OPENAPI_SPECS_TO_FETCH: 100,
         MAX_PAGE_SIZE_BYTES: 3 * 1024 * 1024, // 3MB hard cap per individual page after pruning

--- a/packages/core/utils/html-markdown-pool.ts
+++ b/packages/core/utils/html-markdown-pool.ts
@@ -35,27 +35,27 @@ export class HtmlMarkdownPool {
     }
 
     private createWorker(): Worker {
-        // Try TypeScript file first (for tests/development)
-        const tsUrl = new URL('./html-markdown-worker.ts', import.meta.url);
-        const tsPath = fileURLToPath(tsUrl);
-        
-        if (existsSync(tsPath)) {
-            const worker = new Worker(tsUrl);
+        // Try compiled JavaScript in dist folder first (after npm run build), checking for .ts files here is pointless
+        const distUrl = new URL('../dist/utils/html-markdown-worker.js', import.meta.url);
+        const distPath = fileURLToPath(distUrl);
+
+        if (existsSync(distPath)) {
+            const worker = new Worker(distUrl);
             this.attachWorkerEvents(worker);
             return worker;
         }
-        
+
         // Try JavaScript file (for production or when TS can't be run directly)
         const jsUrl = new URL('./html-markdown-worker.js', import.meta.url);
         const jsPath = fileURLToPath(jsUrl);
-        
+
         if (existsSync(jsPath)) {
             const worker = new Worker(jsUrl);
             this.attachWorkerEvents(worker);
             return worker;
         }
-        
-        throw new Error('Worker file not found: neither .ts nor .js file exists');
+
+        throw new Error('Worker file not found: No compiled .js file found in dist/utils/ or utils/. Run "npm run build" first.');
     }
 
     private attachWorkerEvents(worker: Worker): void {


### PR DESCRIPTION
## 📦 Pull Request Summary

This PR addresses a bug in the sitemap processing when fetching documentation, where missing guardrails would cause us to potentially process thousands of sitemaps. It also removes a pointless .ts file check in the worker pool implementation and replaces it with a check that works for local development as well.

### ✨ What’s Changed

**Sitemap processing guardrails:**
- Added per depth sitemap processing limits and global sitemap processing limits (currently set to a maximum of 20 sitemaps that get ranked for relevance using integration keywords). If the first top-level sitemap already contains 20+ sitemaps (which is often the case for `sitemap_index.xml` files), then this limit takes precedence over any nested sitemaps within the top 20, so it is sequential to some extent. Should only be an edge case that affects top-level sitemaps with a large number of sitemap references, and those usually do not contain further nested sitemaps anyways

**Worker Pool Impl:**
- From my understanding, worker threads in node do not inherit .ts support. This means that the current check for .ts files will always evaluate to true when running the worker threads locally via `npm run test` for example, but will always fail, so this check is actually pointless
- In the prod environment and when running the server with npm run dev, everything gets compiled to .js files anyways, so this was not really causing issues except when running npm run test locally. The replacement checks the dist folder in the correct path for compiled .js before falling back to the prod location, leading `npm run test` to run smoothly on my local setup at least 

## 🎯 Motivation / Context

This was a bug surfaced by trying to set up an AWS integration, which has a `sitemap_index.xml` that references over 9000 sitemaps, leading to a large sitemap processing queue which was causing issues. The worker pool impl. fix was surfaced when trying to run tests locally but should not affect anything other than local test execution.

---

## ✅ Contributor Checklist

- [x] Documentation is up-to-date
- [x] MCP tool descriptions and instructions are up-to-date
- [x] Client SDK updated (if applicable)
- [x] Integration test suite has been run and passes (may not be necessary)
- [x] Unit tests added or updated (if applicable)
- [x] Changes are covered by tests

---

## ⚠️ Compatibility Notes

- [x] ✅ Fully backward compatible
- [ ] ⚠️ Minor behavioral change (non-breaking)
- [ ] ❌ Breaking change — migration steps documented below

<details>
<summary>🔁 Migration Notes (if applicable)</summary>

</details>

---

## 📝 Additional Notes

