### PR TITLE
If payload small add entire payload to self healing context

### DIFF
--- a/packages/core/utils/api.ts
+++ b/packages/core/utils/api.ts
@@ -357,6 +357,10 @@ export async function generateApiConfig({
     const documentation = fullDocs?.content?.length < LanguageModel.contextLength / 4 ?
       fullDocs?.content :
       await integrationManager?.searchDocumentation(apiConfig.urlPath || apiConfig.instruction);
+    let payloadString = JSON.stringify(payload || {});
+    if (payloadString.length > LanguageModel.contextLength / 10) {
+      payloadString = JSON.stringify(sample(payload || {}, 5)).slice(0, LanguageModel.contextLength / 10);
+    }
     const userPrompt = `Generate API configuration for the following:
 
 <instruction>
@@ -388,7 +392,7 @@ ${Object.keys(credentials || {}).map(v => `<<${v}>>`).join(", ")}
 </available_credentials>
 
 <example_payload>
-${JSON.stringify(sample(payload || {}, 5)).slice(0, LanguageModel.contextLength / 10)}
+${payloadString}
 </example_payload>`;
 
     messages.push({


### PR DESCRIPTION
## 📦 Pull Request Summary

We currently always sample even with small payloads which can lead to really stupid situations especially with key value pairs. So, we add the entire payload if it is not too large. 

### ✨ What’s Changed

    let payloadString = JSON.stringify(payload || {});
    if (payloadString.length > LanguageModel.contextLength / 10) {
      payloadString = JSON.stringify(sample(payload || {}, 5)).slice(0, LanguageModel.contextLength / 10);
    }

## 🎯 Motivation / Context

<!-- Why was this change made? What problem does it solve or improvement does it introduce? -->

---

## ⚠️ Compatibility Notes

- [x] ✅ Fully backward compatible
- [ ] ⚠️ Minor behavioral change (non-breaking)
- [ ] ❌ Breaking change — migration steps documented below

<details>
<summary>🔁 Migration Notes (if applicable)</summary>

<!-- Describe any required actions for downstream consumers -->

</details>

---

## 📝 Additional Notes

<!-- Any extra context, links, known issues, or follow-up tasks -->

