### PR TITLE
move integrationOptions to shared templates file

### DIFF
--- a/packages/shared/templates.ts
+++ b/packages/shared/templates.ts
@@ -1483,6 +1483,18 @@ export interface IntegrationConfig {
       preferredAuthType: "apikey",
     }
   }
+
+  export const integrationOptions = [
+    { value: "manual", label: "Custom API", icon: "default" },
+    ...Object.entries(integrations).map(([key, integration]) => ({
+      value: key,
+      label: key
+        .replace(/([A-Z])/g, ' $1')  // Add space before capital letters
+        .replace(/^./, str => str.toUpperCase())  // Capitalize first letter
+        .trim(),  // Remove leading space
+      icon: integration.icon || "default"
+    }))
+  ];
   
   /**
    * Find matching integration for a given URL

--- a/packages/web/src/app/integrations/page.tsx
+++ b/packages/web/src/app/integrations/page.tsx
@@ -20,7 +20,7 @@ import { createOAuthErrorHandler, triggerOAuthFlow } from '@/src/lib/oauth-utils
 import { composeUrl, getIntegrationIcon as getIntegrationIconName } from '@/src/lib/utils';
 import type { Integration } from '@superglue/client';
 import { SuperglueClient, UpsertMode } from '@superglue/client';
-import { integrations as integrationTemplates } from '@superglue/shared';
+import { integrationOptions } from '@superglue/shared';
 import { waitForIntegrationProcessing } from '@superglue/shared/utils';
 import { Clock, FileDown, Globe, Key, Pencil, Plus, RotateCw, Sparkles, Trash2 } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -215,18 +215,6 @@ export default function IntegrationsPage() {
     }), [client]);
 
     const [editingIntegration, setEditingIntegration] = useState<Integration | null>(null);
-
-    const integrationOptions = [
-        { value: "manual", label: "Custom API", icon: "default" },
-        ...Object.entries(integrationTemplates).map(([key, integration]) => ({
-            value: key,
-            label: key
-                .replace(/([A-Z])/g, ' $1')  // Add space before capital letters
-                .replace(/^./, str => str.toUpperCase())  // Capitalize first letter
-                .trim(),  // Remove leading space
-            icon: integration.icon || "default"
-        }))
-    ];
 
     const getSimpleIcon = (name: string): SimpleIcon | null => {
         if (!name || name === "default") return null;

--- a/packages/web/src/components/workflow/WorkflowCreateStepper.tsx
+++ b/packages/web/src/components/workflow/WorkflowCreateStepper.tsx
@@ -6,7 +6,7 @@ import { useToast } from '@/src/hooks/use-toast';
 import { needsUIToTriggerDocFetch } from '@/src/lib/client-utils';
 import { cn, composeUrl, getIntegrationIcon as getIntegrationIconName, getSimpleIcon, inputErrorStyles } from '@/src/lib/utils';
 import { Integration, IntegrationInput, SuperglueClient, UpsertMode, Workflow } from '@superglue/client';
-import { integrations as integrationTemplates } from "@superglue/shared";
+import { integrationOptions } from "@superglue/shared";
 import { waitForIntegrationProcessing } from '@superglue/shared/utils';
 import { ArrowRight, Check, Clock, Globe, Key, Loader2, Pencil, Plus, X } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -121,16 +121,6 @@ export function WorkflowCreateStepper({ onComplete }: WorkflowCreateStepperProps
       setValidationErrors({});
     }
   }, [step]);
-
-
-  const integrationOptions = [
-    { value: "manual", label: "Custom API", icon: "default" },
-    ...Object.entries(integrationTemplates).map(([key, integration]) => ({
-      value: key,
-      label: key.charAt(0).toUpperCase() + key.slice(1),
-      icon: integration.icon || "default"
-    }))
-  ];
 
   const highlightJson = (code: string) => {
     return Prism.highlight(code, Prism.languages.json, 'json');


### PR DESCRIPTION
## 📦 Pull Request Summary

Move the integrationOptions to the shared folder, so that frontend can also use that we dont duplicate code across different files
