### PR TITLE
fix the install of shared dependencies in docker files

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -25,6 +25,12 @@ RUN npm install && \
 COPY packages/core ./packages/core
 COPY packages/shared ./packages/shared
 
+# Install workspace dependencies specifically
+RUN npm install
+
+# Install @superglue/client specifically in shared package for TypeScript resolution
+RUN cd packages/shared && npm install @superglue/client
+
 # Build core and shared packages
 RUN npx turbo run build --filter=@superglue/core --filter=@superglue/shared
 
@@ -54,11 +60,15 @@ COPY packages/shared/package*.json ./packages/shared/
 RUN npm ci --omit=dev && \
     npx playwright install --with-deps chromium
 
+# Install @superglue/client in both core and shared packages for runtime
+RUN cd packages/core && npm install @superglue/client
+RUN cd packages/shared && npm install @superglue/client
+
 # Copy built files from builder stage
 COPY --from=builder /usr/src/app/packages/core/dist ./packages/core/dist
 COPY --from=builder /usr/src/app/packages/shared/dist ./packages/shared/dist
 
-# Expose port for the server
+# Expose ports for both servers
 EXPOSE 3000 3002
 
 # Start the server

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -25,6 +25,12 @@ RUN npm install && \
 COPY packages/web ./packages/web
 COPY packages/shared ./packages/shared
 
+# Install workspace dependencies specifically
+RUN npm install
+
+# Install @superglue/client specifically in shared package for TypeScript resolution
+RUN cd packages/shared && npm install @superglue/client
+
 # Build web and shared packages
 RUN npx turbo run build --filter=@superglue/web --filter=@superglue/shared
 
@@ -44,6 +50,9 @@ COPY packages/shared/package*.json ./packages/shared/
 
 # Install production dependencies
 RUN npm ci --omit=dev
+
+# Install @superglue/client in shared packages for runtime
+RUN cd packages/shared && npm install @superglue/client
 
 # Copy built files from builder stage
 COPY --from=builder /usr/src/app/packages/web/.next ./packages/web/.next

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   server:
     build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7668,6 +7668,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@superglue/client": "^2.3.52",
+        "cron-parser": "^5.3.1",
+        "cron-validate": "^1.5.2",
         "json-schema": "^0.4.0",
         "lodash.isequal": "^4.5.0",
         "lodash.keys": "^4.2.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@superglue/client": "^2.3.52",
+    "cron-parser": "^5.3.1",
+    "cron-validate": "^1.5.2",
     "openai": "^4.85.4",
     "lodash.isequal": "^4.5.0",
     "lodash.xor": "^4.5.0",


### PR DESCRIPTION
This PR fixes the docker files for the web only and server only deployments

it adds the correct dependencies to the shared folder and adds some install commands for the respective docker files