### PR TITLE
fix: use constant-time comparison for API auth token

### DIFF
--- a/packages/web/src/lib/api-auth.ts
+++ b/packages/web/src/lib/api-auth.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import { timingSafeEqual } from "crypto";
 
 export async function authenticateNextJSApiRequest(request: NextRequest): Promise<string | null> {
   const authHeader = request.headers.get("authorization");
@@ -6,5 +7,11 @@ export async function authenticateNextJSApiRequest(request: NextRequest): Promis
   if (!token) return null;
 
   const authToken = process.env.AUTH_TOKEN || process.env.NEXT_PUBLIC_SUPERGLUE_API_KEY;
-  return token === authToken ? token : null;
+  if (!authToken) return null;
+
+  const tokenBuf = Buffer.from(token);
+  const authBuf = Buffer.from(authToken);
+  if (tokenBuf.length !== authBuf.length) return null;
+
+  return timingSafeEqual(tokenBuf, authBuf) ? token : null;
 }


### PR DESCRIPTION
Fixes #671 — Timing side-channel in Bearer token authentication.

## Changes

- Replace `token === authToken` with `crypto.timingSafeEqual(Buffer.from(token), Buffer.from(authToken))`
- Add early return when `authToken` is undefined
- Add length check before `timingSafeEqual` (required by Node.js API)

**CWE-208**: Observable Timing Discrepancy

## Test plan

- [x] Single-file change, 8 lines added
- [x] `timingSafeEqual` is Node.js stdlib (`crypto`), zero new dependencies
- [x] Length check prevents `RangeError` on mismatched buffer sizes
- [x] Behavioral equivalent: still returns token on match, null on mismatch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use constant-time comparison for Bearer token authentication to remove a timing side-channel (CWE-208). Replace `===` with `crypto.timingSafeEqual`, add a buffer length check, and return early when the env token is missing; behavior is unchanged.

<sup>Written for commit 5bdf358ca075f37b0d16cd8af273239dd8b268ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*