### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## What is superglue?
 
-superglue learns how your systems work from your company's knowledge. It performs the implementation that normally requires human coordination and engineering work.
+[superglue](https://superglue.ai) learns how your systems work from your company's knowledge. It performs the implementation that normally requires human coordination and engineering work.
 
 - Implement NetSuite, Sage Intacct, SAP, Business Central or Acumatica in days. Agents map and migrate legacy data, configure the system, and keep data in sync post go-live.
 - Connect ERP, CRM, databases, and internal systems to AI platforms like Claude. Create governed data access for AI agents and track data usage across your org.


### PR DESCRIPTION
## 📦 Pull Request Summary

<!-- Clearly describe what this PR does -->

### ✨ What’s Changed

<!-- Bullet-point summary of high-level changes, ideally grouped by system -->

- **MCP**: ...
- **SDK**: ...
- **Backend Server / API**: ...
- **Other**: ...

---

## 🎯 Motivation / Context

<!-- Why was this change made? What problem does it solve or improvement does it introduce? -->

---

## ✅ Contributor Checklist

- [ ] Documentation is up-to-date
- [ ] MCP tool descriptions and instructions are up-to-date
- [ ] Client SDK updated (if applicable)
- [ ] Integration test suite has been run and passes (may not be necessary)
- [ ] Unit tests added or updated (if applicable)
- [ ] Changes are covered by tests

---

## ⚠️ Compatibility Notes

- [ ] ✅ Fully backward compatible
- [ ] ⚠️ Minor behavioral change (non-breaking)
- [ ] ❌ Breaking change — migration steps documented below

<details>
<summary>🔁 Migration Notes (if applicable)</summary>

<!-- Describe any required actions for downstream consumers -->

</details>

---

## 📝 Additional Notes

<!-- Any extra context, links, known issues, or follow-up tasks -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Linked the first mention of “superglue” in the “What is superglue?” section of the README to the official website to improve discoverability and make it easier for readers to learn more.

<sup>Written for commit c1b05343a9778245727217a2d8a18777595a9f42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superglue-ai/superglue/pull/693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

